### PR TITLE
docs: levelless books, Feather Falling and Quick Charge back as enchantments

### DIFF
--- a/docs/01-smithing-table.md
+++ b/docs/01-smithing-table.md
@@ -10,8 +10,6 @@ Templates found in structures determine the upgrade type. The material in the se
 | Warding | Protection | General damage reduction | Armorer houses, Bastions |
 | Tempering | Unbreaking | Durability | Toolsmiths, Mineshafts |
 | Grinding | Efficiency | Mining/tool speed | Mineshafts, Trial Chambers |
-| Stringing | Quick Charge | Reload speed | Pillager Outposts |
-| Cushioning | Feather Falling | Fall damage (boots) | Villages |
 
 ## Levels and XP Cost by Material
 

--- a/docs/03-enchanting-table.md
+++ b/docs/03-enchanting-table.md
@@ -22,7 +22,9 @@ Each enchantable item has a max slot count determined by its material. Each ench
 
 ## Unlocking — Unified System
 
-One system, one rule for all 33 enchantments. No common/rare tiers.
+One system, one rule for all 35 enchantments. No common/rare tiers.
+
+**Books are levelless keys.** Since the level is chosen at the enchanting table, books no longer display a level. A "Fortune" book is just a "Fortune" book — it unlocks all levels of that enchantment in the catalogue.
 
 **Chiseled Bookshelves + enchanted book** = unlock. Find a book in exploration, place it in a chiseled bookshelf around the table. The enchantment appears in the catalogue. The book is not consumed — permanent key.
 

--- a/docs/04-enchantments.md
+++ b/docs/04-enchantments.md
@@ -1,6 +1,6 @@
-# Complete Enchantment List (33)
+# Complete Enchantment List (35)
 
-## Vanilla Enchantments Kept (21)
+## Vanilla Enchantments Kept (23)
 
 | Enchantment | Max | Item | Effect |
 |---|---|---|---|
@@ -27,6 +27,8 @@
 | Sweeping Edge | III | Sword | Increased sweep damage |
 | Breach | IV | Mace | Reduce enemy armor effectiveness |
 | Knockback | II | Sword/Spear | Push target +3 blocks/level |
+| Feather Falling | IV | Boots | Reduce fall damage |
+| Quick Charge | III | Crossbow | Reduce reload time |
 | Lunge | III | Spear | Propel player forward during jab, costs saturation |
 | Mending | I (3 slots) | Any | XP repairs item instead of filling bar |
 
@@ -55,7 +57,6 @@
 | Fire Protection I-IV | Innate (Copper/Netherite) | Material property |
 | Blast Protection I-IV | Innate (Diamond) | Material property |
 | Projectile Protection I-IV | Innate (Iron) | Material property |
-| Feather Falling I-IV | Smithing (Cushioning) | Stat boost |
 | Sharpness I-V | Smithing (Honing) | Stat boost |
 | Smite I-V | Smithing or enchantment (TBD) | Stat/magic border |
 | Power I-V | Smithing (Honing) | Stat boost |
@@ -63,7 +64,6 @@
 | Impaling I-V | TBD | Template or enchantment |
 | Unbreaking I-III | Smithing (Tempering) | Stat boost |
 | Efficiency I-V | Smithing (Grinding) | Stat boost |
-| Quick Charge I-III | Smithing (Stringing) | Stat boost |
 | Bane of Arthropods I-V | Removed | Niche too narrow |
 | Punch I-II | Removed | Redundant |
 | Lure I-III | Bait System | Craftable baits |
@@ -96,6 +96,8 @@
 | Breach | Breeze Rod |
 | Knockback | Piston |
 | Lunge | Slime Ball |
+| Feather Falling | Feather |
+| Quick Charge | String |
 | Mending | Amethyst Shard |
 | Veil | Phantom Membrane |
 | Last Stand | Echo Shard |
@@ -140,6 +142,8 @@
 | Breach | Trial Chambers |
 | Knockback | Woodland Mansion |
 | Lunge | Trial Chambers |
+| Feather Falling | Village |
+| Quick Charge | Pillager Outpost |
 | Mending | End City |
 | Veil | Ancient City |
 | Last Stand | Trial Chambers |

--- a/docs/05-anvil-and-loot.md
+++ b/docs/05-anvil-and-loot.md
@@ -21,7 +21,7 @@ The anvil is a maintenance workshop. No interaction with enchantments.
 | Structure loot (books) | Curated | Specific books per structure |
 | Fishing | Dead | No more enchanted items |
 | Mob equipment | Dead | Empty enchantment tag override |
-| Librarian trades | Alive | Books capped at level III, serve as unlock keys |
+| Librarian trades | Alive | Levelless books, serve as unlock keys |
 | /enchant | Intact | Preserved for map makers |
 
 # Bait System (Fishing)


### PR DESCRIPTION
Books are now levelless keys — one book per enchantment, no level variants. Feather Falling and Quick Charge moved back from smithing templates to enchantments (35 total). Updated all docs accordingly.