### PR TITLE
Phase 1: Demolition

### DIFF
--- a/src/main/java/com/music4music/enchantmentoverhaul/mixin/AnvilScreenHandlerMixin.java
+++ b/src/main/java/com/music4music/enchantmentoverhaul/mixin/AnvilScreenHandlerMixin.java
@@ -1,0 +1,89 @@
+package com.music4music.enchantmentoverhaul.mixin;
+
+import net.minecraft.component.DataComponentTypes;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.item.ItemStack;
+import net.minecraft.screen.AnvilScreenHandler;
+import net.minecraft.screen.ForgingScreenHandler;
+import net.minecraft.screen.Property;
+import net.minecraft.screen.ScreenHandlerContext;
+import net.minecraft.screen.ScreenHandlerType;
+import net.minecraft.screen.slot.ForgingSlotsManager;
+import net.minecraft.text.Text;
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(AnvilScreenHandler.class)
+public abstract class AnvilScreenHandlerMixin extends ForgingScreenHandler {
+
+    @Shadow @Nullable private String newItemName;
+    @Shadow @Final private Property levelCost;
+
+    private AnvilScreenHandlerMixin(@Nullable ScreenHandlerType<?> type, int syncId, PlayerInventory playerInventory, ScreenHandlerContext context, ForgingSlotsManager forgingSlotsManager) {
+        super(type, syncId, playerInventory, context, forgingSlotsManager);
+    }
+
+    @Inject(method = "updateResult", at = @At("HEAD"), cancellable = true)
+    private void replaceAnvilLogic(CallbackInfo ci) {
+        ItemStack first = this.input.getStack(0);
+        ItemStack second = this.input.getStack(1);
+
+        if (first.isEmpty()) {
+            this.output.setStack(0, ItemStack.EMPTY);
+            this.levelCost.set(0);
+            ci.cancel();
+            return;
+        }
+
+        ItemStack result = first.copy();
+        boolean hasOperation = false;
+
+        if (!second.isEmpty() && first.isDamageable() && first.canRepairWith(second)) {
+            int damage = first.getDamage();
+            int repairPerUnit = first.getMaxDamage() / 4;
+
+            for (int i = 0; i < second.getCount() && damage > 0; i++) {
+                damage = Math.max(0, damage - repairPerUnit);
+            }
+
+            if (damage < first.getDamage()) {
+                result.setDamage(damage);
+                hasOperation = true;
+            }
+        }
+
+        if (this.newItemName != null && !this.newItemName.isBlank()) {
+            if (!this.newItemName.equals(first.getName().getString())) {
+                result.set(DataComponentTypes.CUSTOM_NAME, Text.literal(this.newItemName));
+                hasOperation = true;
+            }
+        } else if (first.contains(DataComponentTypes.CUSTOM_NAME)) {
+            result.remove(DataComponentTypes.CUSTOM_NAME);
+            hasOperation = true;
+        }
+
+        if (!second.isEmpty() && !hasOperation) {
+            this.output.setStack(0, ItemStack.EMPTY);
+            this.levelCost.set(0);
+            ci.cancel();
+            return;
+        }
+
+        if (hasOperation) {
+            result.remove(DataComponentTypes.REPAIR_COST);
+            this.levelCost.set(1);
+            this.output.setStack(0, result);
+        } else {
+            this.output.setStack(0, ItemStack.EMPTY);
+            this.levelCost.set(0);
+        }
+
+        ci.cancel();
+    }
+}

--- a/src/main/java/com/music4music/enchantmentoverhaul/mixin/EnchantBookFactoryMixin.java
+++ b/src/main/java/com/music4music/enchantmentoverhaul/mixin/EnchantBookFactoryMixin.java
@@ -1,0 +1,46 @@
+package com.music4music.enchantmentoverhaul.mixin;
+
+import net.minecraft.component.DataComponentTypes;
+import net.minecraft.component.type.ItemEnchantmentsComponent;
+import net.minecraft.enchantment.Enchantment;
+import net.minecraft.enchantment.Enchantments;
+import net.minecraft.entity.Entity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.registry.entry.RegistryEntry;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.random.Random;
+import net.minecraft.village.TradeOffer;
+import net.minecraft.village.TradeOffers;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(TradeOffers.EnchantBookFactory.class)
+public class EnchantBookFactoryMixin {
+
+    @Inject(method = "create", at = @At("RETURN"), cancellable = true)
+    private void makeBooksLevelless(ServerWorld world, Entity entity, Random random, CallbackInfoReturnable<TradeOffer> cir) {
+        TradeOffer offer = cir.getReturnValue();
+        if (offer == null) return;
+
+        ItemStack book = offer.getSellItem();
+        ItemEnchantmentsComponent enchantments = book.getOrDefault(
+                DataComponentTypes.STORED_ENCHANTMENTS, ItemEnchantmentsComponent.DEFAULT);
+
+        for (RegistryEntry<Enchantment> entry : enchantments.getEnchantments()) {
+            if (entry.matchesKey(Enchantments.MENDING)
+                    || entry.matchesKey(Enchantments.FROST_WALKER)
+                    || entry.matchesKey(Enchantments.BANE_OF_ARTHROPODS)) {
+                cir.setReturnValue(null);
+                return;
+            }
+        }
+
+        ItemEnchantmentsComponent.Builder builder = new ItemEnchantmentsComponent.Builder(ItemEnchantmentsComponent.DEFAULT);
+        for (RegistryEntry<Enchantment> entry : enchantments.getEnchantments()) {
+            builder.set(entry, 1);
+        }
+        book.set(DataComponentTypes.STORED_ENCHANTMENTS, builder.build());
+    }
+}

--- a/src/main/java/com/music4music/enchantmentoverhaul/mixin/EnchantBookFactoryMixin.java
+++ b/src/main/java/com/music4music/enchantmentoverhaul/mixin/EnchantBookFactoryMixin.java
@@ -1,12 +1,6 @@
 package com.music4music.enchantmentoverhaul.mixin;
 
-import net.minecraft.component.DataComponentTypes;
-import net.minecraft.component.type.ItemEnchantmentsComponent;
-import net.minecraft.enchantment.Enchantment;
-import net.minecraft.enchantment.Enchantments;
 import net.minecraft.entity.Entity;
-import net.minecraft.item.ItemStack;
-import net.minecraft.registry.entry.RegistryEntry;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.math.random.Random;
 import net.minecraft.village.TradeOffer;
@@ -19,28 +13,8 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 @Mixin(TradeOffers.EnchantBookFactory.class)
 public class EnchantBookFactoryMixin {
 
-    @Inject(method = "create", at = @At("RETURN"), cancellable = true)
-    private void makeBooksLevelless(ServerWorld world, Entity entity, Random random, CallbackInfoReturnable<TradeOffer> cir) {
-        TradeOffer offer = cir.getReturnValue();
-        if (offer == null) return;
-
-        ItemStack book = offer.getSellItem();
-        ItemEnchantmentsComponent enchantments = book.getOrDefault(
-                DataComponentTypes.STORED_ENCHANTMENTS, ItemEnchantmentsComponent.DEFAULT);
-
-        for (RegistryEntry<Enchantment> entry : enchantments.getEnchantments()) {
-            if (entry.matchesKey(Enchantments.MENDING)
-                    || entry.matchesKey(Enchantments.FROST_WALKER)
-                    || entry.matchesKey(Enchantments.BANE_OF_ARTHROPODS)) {
-                cir.setReturnValue(null);
-                return;
-            }
-        }
-
-        ItemEnchantmentsComponent.Builder builder = new ItemEnchantmentsComponent.Builder(ItemEnchantmentsComponent.DEFAULT);
-        for (RegistryEntry<Enchantment> entry : enchantments.getEnchantments()) {
-            builder.set(entry, 1);
-        }
-        book.set(DataComponentTypes.STORED_ENCHANTMENTS, builder.build());
+    @Inject(method = "create", at = @At("HEAD"), cancellable = true)
+    private void disableEnchantedBookTrades(ServerWorld world, Entity entity, Random random, CallbackInfoReturnable<TradeOffer> cir) {
+        cir.setReturnValue(null);
     }
 }

--- a/src/main/java/com/music4music/enchantmentoverhaul/mixin/EnchantRandomlyLootFunctionMixin.java
+++ b/src/main/java/com/music4music/enchantmentoverhaul/mixin/EnchantRandomlyLootFunctionMixin.java
@@ -1,0 +1,18 @@
+package com.music4music.enchantmentoverhaul.mixin;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.loot.context.LootContext;
+import net.minecraft.loot.function.EnchantRandomlyLootFunction;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(EnchantRandomlyLootFunction.class)
+public class EnchantRandomlyLootFunctionMixin {
+
+    @Inject(method = "process", at = @At("HEAD"), cancellable = true)
+    private void disableRandomLootEnchanting(ItemStack stack, LootContext context, CallbackInfoReturnable<ItemStack> cir) {
+        cir.setReturnValue(stack);
+    }
+}

--- a/src/main/java/com/music4music/enchantmentoverhaul/mixin/EnchantWithLevelsLootFunctionMixin.java
+++ b/src/main/java/com/music4music/enchantmentoverhaul/mixin/EnchantWithLevelsLootFunctionMixin.java
@@ -1,0 +1,18 @@
+package com.music4music.enchantmentoverhaul.mixin;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.loot.context.LootContext;
+import net.minecraft.loot.function.EnchantWithLevelsLootFunction;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(EnchantWithLevelsLootFunction.class)
+public class EnchantWithLevelsLootFunctionMixin {
+
+    @Inject(method = "process", at = @At("HEAD"), cancellable = true)
+    private void disableLootEnchanting(ItemStack stack, LootContext context, CallbackInfoReturnable<ItemStack> cir) {
+        cir.setReturnValue(stack);
+    }
+}

--- a/src/main/java/com/music4music/enchantmentoverhaul/mixin/EnchantmentScreenHandlerMixin.java
+++ b/src/main/java/com/music4music/enchantmentoverhaul/mixin/EnchantmentScreenHandlerMixin.java
@@ -1,0 +1,24 @@
+package com.music4music.enchantmentoverhaul.mixin;
+
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.inventory.Inventory;
+import net.minecraft.screen.EnchantmentScreenHandler;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(EnchantmentScreenHandler.class)
+public class EnchantmentScreenHandlerMixin {
+
+    @Inject(method = "onButtonClick", at = @At("HEAD"), cancellable = true)
+    private void disableEnchanting(PlayerEntity player, int id, CallbackInfoReturnable<Boolean> cir) {
+        cir.setReturnValue(false);
+    }
+
+    @Inject(method = "onContentChanged", at = @At("HEAD"), cancellable = true)
+    private void disableEnchantmentGeneration(Inventory inventory, CallbackInfo ci) {
+        ci.cancel();
+    }
+}

--- a/src/main/java/com/music4music/enchantmentoverhaul/mixin/MobEntityMixin.java
+++ b/src/main/java/com/music4music/enchantmentoverhaul/mixin/MobEntityMixin.java
@@ -1,0 +1,19 @@
+package com.music4music.enchantmentoverhaul.mixin;
+
+import net.minecraft.entity.mob.MobEntity;
+import net.minecraft.util.math.random.Random;
+import net.minecraft.world.LocalDifficulty;
+import net.minecraft.world.ServerWorldAccess;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(MobEntity.class)
+public class MobEntityMixin {
+
+    @Inject(method = "updateEnchantments", at = @At("HEAD"), cancellable = true)
+    protected void disableMobEnchantments(ServerWorldAccess world, Random random, LocalDifficulty localDifficulty, CallbackInfo ci) {
+        ci.cancel();
+    }
+}

--- a/src/main/resources/enchantment-overhaul.mixins.json
+++ b/src/main/resources/enchantment-overhaul.mixins.json
@@ -2,7 +2,14 @@
     "required": true,
     "package": "com.music4music.enchantmentoverhaul.mixin",
     "compatibilityLevel": "JAVA_21",
-    "mixins": [],
+    "mixins": [
+        "EnchantmentScreenHandlerMixin",
+        "AnvilScreenHandlerMixin",
+        "EnchantWithLevelsLootFunctionMixin",
+        "EnchantRandomlyLootFunctionMixin",
+        "MobEntityMixin",
+        "EnchantBookFactoryMixin"
+    ],
     "client": [],
     "injectors": {
         "defaultRequire": 1


### PR DESCRIPTION
Disables all vanilla enchantment acquisition and modification systems, establishing a clean slate for Phase 2 reconstruction.

Six mixins cover the entire demolition scope: enchanting table disabled, anvil restricted to repair and rename only (fixed 1 XP, no prior work penalty, no Too Expensive), all loot enchanting removed (EnchantWithLevels + EnchantRandomly), mob equipment enchanting stripped, and librarian enchanted book trades disabled. Bane of Arthropods is effectively removed since no acquisition path remains.

Closes #1, #2, #3, #4, #5, #6, #7, #8, #9, #10