### PR TITLE
feat: enchanting table catalogue UI and grindstone rework

### DIFF
--- a/src/main/java/com/akitain/enchantmentoverhaul/EnchantmentOverhaul.java
+++ b/src/main/java/com/akitain/enchantmentoverhaul/EnchantmentOverhaul.java
@@ -1,6 +1,7 @@
 package com.akitain.enchantmentoverhaul;
 
 import com.akitain.enchantmentoverhaul.component.ModComponents;
+import com.akitain.enchantmentoverhaul.enchant.ModScreenHandlers;
 import net.fabricmc.api.ModInitializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -13,6 +14,7 @@ public class EnchantmentOverhaul implements ModInitializer {
     @Override
     public void onInitialize() {
         ModComponents.register();
+        ModScreenHandlers.register();
         LOGGER.info("Enchantment Overhaul loaded");
     }
 }

--- a/src/main/java/com/akitain/enchantmentoverhaul/EnchantmentOverhaulClient.java
+++ b/src/main/java/com/akitain/enchantmentoverhaul/EnchantmentOverhaulClient.java
@@ -1,8 +1,11 @@
 package com.akitain.enchantmentoverhaul;
 
+import com.akitain.enchantmentoverhaul.client.CatalogueScreen;
+import com.akitain.enchantmentoverhaul.enchant.ModScreenHandlers;
 import com.akitain.enchantmentoverhaul.enchant.SlotSystem;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.item.v1.ItemTooltipCallback;
+import net.minecraft.client.gui.screen.ingame.HandledScreens;
 import net.minecraft.item.ItemStack;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
@@ -11,6 +14,8 @@ public class EnchantmentOverhaulClient implements ClientModInitializer {
 
     @Override
     public void onInitializeClient() {
+        HandledScreens.register(ModScreenHandlers.CATALOGUE, CatalogueScreen::new);
+
         ItemTooltipCallback.EVENT.register((stack, context, type, lines) -> {
             if (SlotSystem.getBaseMaxSlots(stack) <= 0) return;
             lines.add(Text.literal(slotText(stack)).formatted(slotColor(stack)));

--- a/src/main/java/com/akitain/enchantmentoverhaul/client/CatalogueScreen.java
+++ b/src/main/java/com/akitain/enchantmentoverhaul/client/CatalogueScreen.java
@@ -1,0 +1,460 @@
+package com.akitain.enchantmentoverhaul.client;
+
+import com.akitain.enchantmentoverhaul.enchant.CatalogueScreenHandler;
+import com.akitain.enchantmentoverhaul.enchant.CatalogueScreenHandler.CatalogueEntry;
+import com.akitain.enchantmentoverhaul.enchant.EnchantmentCosts;
+import com.akitain.enchantmentoverhaul.enchant.SlotSystem;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.Click;
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.gui.screen.ingame.HandledScreen;
+import net.minecraft.client.sound.PositionedSoundInstance;
+import net.minecraft.enchantment.Enchantment;
+import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.registry.RegistryKey;
+import net.minecraft.registry.tag.EnchantmentTags;
+import net.minecraft.screen.slot.Slot;
+import net.minecraft.sound.SoundEvents;
+import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
+import net.minecraft.util.math.MathHelper;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Environment(EnvType.CLIENT)
+public class CatalogueScreen extends HandledScreen<CatalogueScreenHandler> {
+
+    private static final int BG_W = 280;
+    private static final int BG_H = 230;
+
+    private static final int CAT_X = 52;
+    private static final int CAT_Y = 20;
+    private static final int CAT_W = 216;
+    private static final int ROW_H = 20;
+    private static final int VISIBLE_ROWS = 5;
+    private static final int CAT_H = ROW_H * VISIBLE_ROWS;
+
+    private static final int SCROLLBAR_W = 6;
+
+    private static final int BTN_X = 8;
+    private static final int BTN_Y = 108;
+    private static final int BTN_W = 36;
+    private static final int BTN_H = 14;
+
+    private static final int SLOT_BAR_Y = 126;
+
+    private static final int PURPLE_DARK = 0xFF1A0A2E;
+    private static final int PURPLE_MID = 0xFF2D1250;
+    private static final int PURPLE_LIGHT = 0xFF8050C0;
+    private static final int PURPLE_BRIGHT = 0xFFC080FF;
+    private static final int TEXT_LIGHT = 0xFFE0D8F0;
+    private static final int TEXT_DIM = 0xFF9080B0;
+    private static final int GREEN = 0xFF55FF55;
+    private static final int RED = 0xFFFF5555;
+    private static final int GOLD = 0xFFFFAA00;
+    private static final int BG = 0xFFC6C6C6;
+    private static final int SLOT_BG = 0xFF8B8B8B;
+    private static final int BORDER_L = 0xFFFFFFFF;
+    private static final int BORDER_D = 0xFF555555;
+
+    private float scrollAmount;
+    private int scrollOffset;
+    private boolean scrolling;
+    private ItemStack lastItem = ItemStack.EMPTY;
+
+    public CatalogueScreen(CatalogueScreenHandler handler, PlayerInventory inventory, Text title) {
+        super(handler, inventory, title);
+        this.backgroundWidth = BG_W;
+        this.backgroundHeight = BG_H;
+        this.titleX = 8;
+        this.titleY = 6;
+        this.playerInventoryTitleX = 59;
+        this.playerInventoryTitleY = BG_H - 94;
+    }
+
+    @Override
+    protected void init() {
+        super.init();
+        handler.rebuildEntries();
+    }
+
+    @Override
+    public void render(DrawContext context, int mouseX, int mouseY, float deltaTicks) {
+        checkItemChanged();
+        super.render(context, mouseX, mouseY, deltaTicks);
+        drawCatalogueTooltip(context, mouseX, mouseY);
+        drawMouseoverTooltip(context, mouseX, mouseY);
+    }
+
+    private void checkItemChanged() {
+        ItemStack current = handler.getSlot(0).getStack();
+        if (!ItemStack.areEqual(current, lastItem)) {
+            lastItem = current.copy();
+            handler.rebuildEntries();
+            scrollAmount = 0;
+            scrollOffset = 0;
+        }
+    }
+
+    @Override
+    protected void drawBackground(DrawContext context, float deltaTicks, int mouseX, int mouseY) {
+        int x = this.x, y = this.y;
+
+        context.fill(x, y, x + BG_W, y + BG_H, BG);
+        border3D(context, x, y, BG_W, BG_H, BORDER_L, BORDER_D);
+
+        drawInputSlots(context, x, y);
+        drawCatalogue(context, x, y, mouseX, mouseY);
+        drawSlotBar(context, x, y);
+        drawEnchantButton(context, x, y, mouseX, mouseY);
+        drawPlayerSlotBorders(context, x, y);
+    }
+
+    private void drawInputSlots(DrawContext context, int x, int y) {
+        for (int i = 0; i < 3; i++) {
+            Slot slot = handler.slots.get(i);
+            slotBorder(context, x + slot.x - 1, y + slot.y - 1);
+        }
+    }
+
+    @Override
+    protected void drawForeground(DrawContext context, int mouseX, int mouseY) {
+        context.drawText(textRenderer, this.title, titleX, titleY, 0x404040, false);
+
+        Slot s0 = handler.slots.get(0);
+        Slot s1 = handler.slots.get(1);
+        Slot s2 = handler.slots.get(2);
+        context.drawText(textRenderer, "Item", s0.x - 1, s0.y + 18, TEXT_DIM, true);
+        context.drawText(textRenderer, "Lapis", s1.x - 1, s1.y + 18, TEXT_DIM, true);
+        context.drawText(textRenderer, "Reagent", s2.x - 4, s2.y + 18, TEXT_DIM, true);
+
+        context.drawText(textRenderer, this.playerInventoryTitle, playerInventoryTitleX, playerInventoryTitleY, 0x404040, false);
+    }
+
+    private void drawCatalogue(DrawContext context, int x, int y, int mouseX, int mouseY) {
+        int cx = x + CAT_X, cy = y + CAT_Y;
+
+        context.fill(cx, cy, cx + CAT_W, cy + CAT_H, PURPLE_DARK);
+        borderInset(context, cx, cy, CAT_W, CAT_H);
+
+        context.drawTextWithShadow(textRenderer, "Catalogue", cx, cy - 12, TEXT_LIGHT);
+
+        List<CatalogueEntry> entries = handler.getEntries();
+        if (entries.isEmpty()) {
+            String hint = handler.getSlot(0).getStack().isEmpty()
+                    ? "Place an item to enchant"
+                    : "No enchantments unlocked";
+            context.drawTextWithShadow(textRenderer, hint,
+                    cx + (CAT_W - textRenderer.getWidth(hint)) / 2,
+                    cy + CAT_H / 2 - 4, TEXT_DIM);
+            return;
+        }
+
+        int end = Math.min(scrollOffset + VISIBLE_ROWS, entries.size());
+        for (int i = scrollOffset; i < end; i++) {
+            int ry = cy + (i - scrollOffset) * ROW_H;
+            drawRow(context, entries.get(i), i, cx, ry, mouseX, mouseY);
+        }
+
+        drawScrollbar(context, cx + CAT_W - SCROLLBAR_W - 1, cy + 1, CAT_H - 2);
+    }
+
+    private void drawRow(DrawContext context, CatalogueEntry entry, int idx, int cx, int ry, int mx, int my) {
+        boolean selected = idx == handler.getSelectedIndex();
+        boolean hovered = mx >= cx && mx < cx + CAT_W && my >= ry && my < ry + ROW_H;
+
+        if (selected) {
+            context.fill(cx + 1, ry, cx + CAT_W - SCROLLBAR_W - 2, ry + ROW_H, 0x50A060FF);
+        } else if (hovered) {
+            context.fill(cx + 1, ry, cx + CAT_W - SCROLLBAR_W - 2, ry + ROW_H, 0x30FFFFFF);
+        }
+
+        int ty = ry + (ROW_H - 8) / 2;
+        boolean curse = entry.entry().isIn(EnchantmentTags.CURSE);
+        int nameColor = curse ? 0xFFFF6666 : TEXT_LIGHT;
+        String name = entry.entry().value().description().getString();
+        context.drawTextWithShadow(textRenderer, name, cx + 6, ty, nameColor);
+
+        int lvX = cx + CAT_W - SCROLLBAR_W - 8 - entry.maxLevel() * 14;
+        int selLv = selected ? handler.getSelectedLevel() : 0;
+
+        for (int lv = 1; lv <= entry.maxLevel(); lv++) {
+            boolean lvSel = selected && lv == selLv;
+            int bg = lvSel ? PURPLE_LIGHT : PURPLE_MID;
+            context.fill(lvX, ry + 3, lvX + 12, ry + ROW_H - 3, bg);
+            String r = toRoman(lv);
+            int tw = textRenderer.getWidth(r);
+            context.drawTextWithShadow(textRenderer, r, lvX + (12 - tw) / 2, ty, lvSel ? GOLD : TEXT_DIM);
+            lvX += 14;
+        }
+    }
+
+    private void drawCatalogueTooltip(DrawContext context, int mx, int my) {
+        int cx = this.x + CAT_X, cy = this.y + CAT_Y;
+        if (mx < cx || mx >= cx + CAT_W || my < cy || my >= cy + CAT_H) return;
+
+        List<CatalogueEntry> entries = handler.getEntries();
+        int idx = scrollOffset + (my - cy) / ROW_H;
+        if (idx >= entries.size()) return;
+
+        CatalogueEntry entry = entries.get(idx);
+        RegistryKey<Enchantment> key = entry.key();
+        boolean selected = idx == handler.getSelectedIndex();
+        int level = selected ? handler.getSelectedLevel() : 1;
+
+        Item reagentItem = EnchantmentCosts.reagent(key);
+        int lapisCost = EnchantmentCosts.lapisCost(level);
+        int reagentCost = EnchantmentCosts.reagentCost(level, handler.getNormalBookshelves());
+        int xpCost = EnchantmentCosts.xpCost(key, level);
+        int slotCost = EnchantmentCosts.slotCost(key, level);
+
+        ItemStack item = handler.getSlot(0).getStack();
+        ItemStack lapis = handler.getSlot(1).getStack();
+        ItemStack reagent = handler.getSlot(2).getStack();
+        int playerXp = MinecraftClient.getInstance().player.experienceLevel;
+
+        boolean hasLapis = lapis.getCount() >= lapisCost;
+        boolean hasReagent = reagent.isOf(reagentItem) && reagent.getCount() >= reagentCost;
+        boolean hasXp = playerXp >= xpCost;
+        boolean hasSlots = SlotSystem.getAvailableSlots(item) >= slotCost;
+
+        String levelLabel = selected ? " " + toRoman(level) : "";
+        List<Text> tooltip = new ArrayList<>();
+        tooltip.add(Text.literal(entry.entry().value().description().getString() + levelLabel)
+                .formatted(entry.entry().isIn(EnchantmentTags.CURSE) ? Formatting.RED : Formatting.LIGHT_PURPLE));
+        tooltip.add(Text.empty());
+        tooltip.add(costLine("Lapis Lazuli", lapisCost, hasLapis));
+        tooltip.add(costLine(reagentItem.getName().getString(), reagentCost, hasReagent));
+        tooltip.add(costLine("XP Levels", xpCost, hasXp));
+        tooltip.add(costLine("Slots", slotCost, hasSlots));
+
+        if (handler.getNormalBookshelves() > 0) {
+            int pct = (int) (EnchantmentCosts.baseReagentCost(level) > 0
+                    ? (1.0 - (double) reagentCost / EnchantmentCosts.baseReagentCost(level)) * 100 : 0);
+            tooltip.add(Text.empty());
+            tooltip.add(Text.literal("Bookshelves: " + handler.getNormalBookshelves() + " (-" + pct + "% reagent)")
+                    .formatted(Formatting.DARK_GRAY));
+        }
+
+        context.drawTooltip(textRenderer, tooltip, mx, my);
+    }
+
+    private Text costLine(String label, int amount, boolean has) {
+        Formatting color = has ? Formatting.GREEN : Formatting.RED;
+        return Text.literal(label + ": ").formatted(Formatting.GRAY)
+                .append(Text.literal(String.valueOf(amount)).formatted(color));
+    }
+
+    private void drawScrollbar(DrawContext context, int sx, int sy, int sh) {
+        context.fill(sx, sy, sx + SCROLLBAR_W, sy + sh, 0x40000000);
+        if (!shouldScroll()) return;
+
+        int thumbH = Math.max(10, sh * VISIBLE_ROWS / handler.getEntries().size());
+        int thumbY = sy + (int) ((sh - thumbH) * scrollAmount);
+        context.fill(sx, thumbY, sx + SCROLLBAR_W, thumbY + thumbH, PURPLE_LIGHT);
+    }
+
+    private void drawSlotBar(DrawContext context, int x, int y) {
+        ItemStack item = handler.getSlot(0).getStack();
+        if (item.isEmpty()) return;
+
+        int max = SlotSystem.getMaxSlots(item);
+        int used = SlotSystem.getUsedSlots(item);
+        if (max <= 0) return;
+
+        int pendingCost = 0;
+        if (handler.getSelectedIndex() >= 0 && handler.getSelectedIndex() < handler.getEntries().size()) {
+            CatalogueEntry e = handler.getEntries().get(handler.getSelectedIndex());
+            pendingCost = EnchantmentCosts.slotCost(e.key(), handler.getSelectedLevel());
+        }
+
+        int barX = x + CAT_X;
+        int barY = y + SLOT_BAR_Y;
+        int lw = 12, gap = 2;
+        int totalW = max * lw + (max - 1) * gap;
+        int sx = barX + (CAT_W - totalW) / 2;
+
+        for (int i = 0; i < max; i++) {
+            int lx = sx + i * (lw + gap);
+            if (i < used) {
+                context.fill(lx, barY, lx + lw, barY + 8, PURPLE_LIGHT);
+            } else if (i < used + pendingCost) {
+                boolean blink = (System.currentTimeMillis() / 400) % 2 == 0;
+                context.fill(lx, barY, lx + lw, barY + 8, blink ? PURPLE_BRIGHT : 0xFF5030A0);
+            } else {
+                context.fill(lx, barY, lx + lw, barY + 8, PURPLE_MID);
+            }
+        }
+
+        context.drawTextWithShadow(textRenderer, used + "/" + max, sx + totalW + 6, barY, TEXT_LIGHT);
+    }
+
+    private void drawEnchantButton(DrawContext context, int x, int y, int mx, int my) {
+        int bx = x + BTN_X, by = y + BTN_Y;
+        boolean can = canEnchantNow();
+        boolean hover = mx >= bx && mx < bx + BTN_W && my >= by && my < by + BTN_H;
+
+        int bg = can ? (hover ? 0xFF50B050 : 0xFF408040) : 0xFF555555;
+        context.fill(bx, by, bx + BTN_W, by + BTN_H, bg);
+        border3D(context, bx, by, BTN_W, BTN_H,
+                can ? 0xFF70D070 : 0xFF777777,
+                can ? 0xFF206020 : 0xFF333333);
+
+        String label = "Enchant";
+        context.drawTextWithShadow(textRenderer, label,
+                bx + (BTN_W - textRenderer.getWidth(label)) / 2,
+                by + (BTN_H - 8) / 2,
+                can ? 0xFFFFFFFF : 0xFF999999);
+    }
+
+    private void drawPlayerSlotBorders(DrawContext context, int x, int y) {
+        for (int i = 3; i < handler.slots.size(); i++) {
+            Slot slot = handler.slots.get(i);
+            slotBorder(context, x + slot.x - 1, y + slot.y - 1);
+        }
+    }
+
+    private boolean canEnchantNow() {
+        if (handler.getSelectedIndex() < 0) return false;
+        List<CatalogueEntry> entries = handler.getEntries();
+        if (handler.getSelectedIndex() >= entries.size()) return false;
+
+        CatalogueEntry entry = entries.get(handler.getSelectedIndex());
+
+        int level = handler.getSelectedLevel();
+        RegistryKey<Enchantment> key = entry.key();
+        ItemStack item = handler.getSlot(0).getStack();
+        ItemStack lapis = handler.getSlot(1).getStack();
+        ItemStack reagent = handler.getSlot(2).getStack();
+
+        if (MinecraftClient.getInstance().player.isCreative()) return true;
+
+        return lapis.getCount() >= EnchantmentCosts.lapisCost(level)
+                && reagent.isOf(EnchantmentCosts.reagent(key))
+                && reagent.getCount() >= EnchantmentCosts.reagentCost(level, handler.getNormalBookshelves())
+                && MinecraftClient.getInstance().player.experienceLevel >= EnchantmentCosts.xpCost(key, level)
+                && SlotSystem.getAvailableSlots(item) >= EnchantmentCosts.slotCost(key, level);
+    }
+
+    // --- Input ---
+
+    @Override
+    public boolean mouseClicked(Click click, boolean doubled) {
+        double mx = click.x(), my = click.y();
+        int x = this.x, y = this.y;
+
+        if (clickEnchant(mx, my, x, y)) return true;
+        if (clickRow(mx, my, x, y)) return true;
+        if (clickScroll(mx, my, x, y)) return true;
+
+        return super.mouseClicked(click, doubled);
+    }
+
+    private boolean clickEnchant(double mx, double my, int x, int y) {
+        int bx = x + BTN_X, by = y + BTN_Y;
+        if (mx < bx || mx >= bx + BTN_W || my < by || my >= by + BTN_H) return false;
+        if (!canEnchantNow()) return false;
+        MinecraftClient.getInstance().getSoundManager().play(PositionedSoundInstance.ui(SoundEvents.BLOCK_ENCHANTMENT_TABLE_USE, 1.0F));
+        client.interactionManager.clickButton(handler.syncId, CatalogueScreenHandler.ENCHANT_BUTTON_ID);
+        return true;
+    }
+
+    private boolean clickRow(double mx, double my, int x, int y) {
+        int cx = x + CAT_X, cy = y + CAT_Y;
+        if (mx < cx || mx >= cx + CAT_W - SCROLLBAR_W || my < cy || my >= cy + CAT_H) return false;
+
+        List<CatalogueEntry> entries = handler.getEntries();
+        int idx = scrollOffset + (int) (my - cy) / ROW_H;
+        if (idx >= entries.size()) return false;
+
+        CatalogueEntry entry = entries.get(idx);
+        int lvX = cx + CAT_W - SCROLLBAR_W - 8 - entry.maxLevel() * 14;
+        int level = 1;
+        if (mx >= lvX) {
+            int lvIdx = (int) (mx - lvX) / 14;
+            if (lvIdx >= 0 && lvIdx < entry.maxLevel()) level = lvIdx + 1;
+        }
+
+        handler.setSelection(idx, level);
+        MinecraftClient.getInstance().getSoundManager().play(PositionedSoundInstance.ui(SoundEvents.UI_BUTTON_CLICK.value(), 1.0F));
+        client.interactionManager.clickButton(handler.syncId, idx * 10 + (level - 1));
+        return true;
+    }
+
+    private boolean clickScroll(double mx, double my, int x, int y) {
+        int sx = x + CAT_X + CAT_W - SCROLLBAR_W - 1;
+        int sy = y + CAT_Y;
+        if (mx >= sx && mx < sx + SCROLLBAR_W && my >= sy && my < sy + CAT_H && shouldScroll()) {
+            scrolling = true;
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public boolean mouseDragged(Click click, double dx, double dy) {
+        if (scrolling && shouldScroll()) {
+            float top = this.y + CAT_Y;
+            scrollAmount = MathHelper.clamp((float) (click.y() - top) / CAT_H, 0, 1);
+            scrollOffset = (int) (scrollAmount * getMaxScroll());
+            return true;
+        }
+        return super.mouseDragged(click, dx, dy);
+    }
+
+    @Override
+    public boolean mouseReleased(Click click) {
+        scrolling = false;
+        return super.mouseReleased(click);
+    }
+
+    @Override
+    public boolean mouseScrolled(double mx, double my, double hAmt, double vAmt) {
+        if (super.mouseScrolled(mx, my, hAmt, vAmt)) return true;
+        if (!shouldScroll()) return false;
+        int max = getMaxScroll();
+        scrollOffset = MathHelper.clamp(scrollOffset - (int) vAmt, 0, max);
+        scrollAmount = max > 0 ? (float) scrollOffset / max : 0;
+        return true;
+    }
+
+    private boolean shouldScroll() { return handler.getEntries().size() > VISIBLE_ROWS; }
+    private int getMaxScroll() { return Math.max(0, handler.getEntries().size() - VISIBLE_ROWS); }
+
+    // --- Drawing helpers ---
+
+    private void border3D(DrawContext ctx, int x, int y, int w, int h, int light, int dark) {
+        ctx.fill(x, y, x + w, y + 1, light);
+        ctx.fill(x, y, x + 1, y + h, light);
+        ctx.fill(x + w - 1, y + 1, x + w, y + h, dark);
+        ctx.fill(x + 1, y + h - 1, x + w, y + h, dark);
+    }
+
+    private void borderInset(DrawContext ctx, int x, int y, int w, int h) {
+        border3D(ctx, x, y, w, h, BORDER_D, BORDER_L);
+    }
+
+    private void slotBorder(DrawContext ctx, int x, int y) {
+        ctx.fill(x, y, x + 18, y + 1, BORDER_D);
+        ctx.fill(x, y, x + 1, y + 18, BORDER_D);
+        ctx.fill(x + 17, y + 1, x + 18, y + 18, BORDER_L);
+        ctx.fill(x + 1, y + 17, x + 18, y + 18, BORDER_L);
+        ctx.fill(x + 1, y + 1, x + 17, y + 17, SLOT_BG);
+    }
+
+    private static String toRoman(int n) {
+        return switch (n) {
+            case 1 -> "I";
+            case 2 -> "II";
+            case 3 -> "III";
+            case 4 -> "IV";
+            case 5 -> "V";
+            default -> String.valueOf(n);
+        };
+    }
+}

--- a/src/main/java/com/akitain/enchantmentoverhaul/enchant/BookshelfScanner.java
+++ b/src/main/java/com/akitain/enchantmentoverhaul/enchant/BookshelfScanner.java
@@ -1,0 +1,66 @@
+package com.akitain.enchantmentoverhaul.enchant;
+
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.Blocks;
+import net.minecraft.block.EnchantingTableBlock;
+import net.minecraft.block.entity.ChiseledBookshelfBlockEntity;
+import net.minecraft.component.DataComponentTypes;
+import net.minecraft.component.type.ItemEnchantmentsComponent;
+import net.minecraft.enchantment.Enchantment;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+import net.minecraft.registry.RegistryKey;
+import net.minecraft.registry.entry.RegistryEntry;
+import net.minecraft.registry.tag.BlockTags;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class BookshelfScanner {
+
+    public record ScanResult(Set<RegistryKey<Enchantment>> unlocked, int normalBookshelves) {}
+
+    public static ScanResult scan(World world, BlockPos tablePos) {
+        Set<RegistryKey<Enchantment>> unlocked = new HashSet<>();
+        int normalCount = 0;
+
+        for (BlockPos offset : EnchantingTableBlock.POWER_PROVIDER_OFFSETS) {
+            BlockPos shelfPos = tablePos.add(offset);
+            BlockPos betweenPos = tablePos.add(offset.getX() / 2, offset.getY(), offset.getZ() / 2);
+
+            if (!world.getBlockState(betweenPos).isIn(BlockTags.ENCHANTMENT_POWER_TRANSMITTER)) continue;
+
+            BlockState state = world.getBlockState(shelfPos);
+
+            if (state.isOf(Blocks.CHISELED_BOOKSHELF)) {
+                collectEnchantments(world, shelfPos, unlocked);
+            } else if (state.isIn(BlockTags.ENCHANTMENT_POWER_PROVIDER)) {
+                normalCount++;
+            }
+        }
+
+        return new ScanResult(unlocked, normalCount);
+    }
+
+    private static void collectEnchantments(World world, BlockPos pos, Set<RegistryKey<Enchantment>> unlocked) {
+        if (!(world.getBlockEntity(pos) instanceof ChiseledBookshelfBlockEntity shelf)) return;
+
+        for (int i = 0; i < ChiseledBookshelfBlockEntity.MAX_BOOKS; i++) {
+            ItemStack book = shelf.getStack(i);
+            if (!book.isOf(Items.ENCHANTED_BOOK)) continue;
+
+            ItemEnchantmentsComponent stored = book.getOrDefault(DataComponentTypes.STORED_ENCHANTMENTS, ItemEnchantmentsComponent.DEFAULT);
+            for (Object2IntMap.Entry<RegistryEntry<Enchantment>> entry : stored.getEnchantmentEntries()) {
+                entry.getKey().getKey().ifPresent(unlocked::add);
+            }
+        }
+    }
+
+    public static double reagentDiscount(int normalBookshelves) {
+        int capped = Math.min(normalBookshelves, 15);
+        return capped * (0.5 / 15.0);
+    }
+}

--- a/src/main/java/com/akitain/enchantmentoverhaul/enchant/CatalogueData.java
+++ b/src/main/java/com/akitain/enchantmentoverhaul/enchant/CatalogueData.java
@@ -1,0 +1,19 @@
+package com.akitain.enchantmentoverhaul.enchant;
+
+import net.minecraft.network.RegistryByteBuf;
+import net.minecraft.network.codec.PacketCodec;
+import net.minecraft.network.codec.PacketCodecs;
+import net.minecraft.util.Identifier;
+
+import java.util.List;
+
+public record CatalogueData(List<Identifier> unlocked, int normalBookshelves) {
+
+    public static final PacketCodec<RegistryByteBuf, CatalogueData> PACKET_CODEC = PacketCodec.tuple(
+            Identifier.PACKET_CODEC.collect(PacketCodecs.toList()),
+            CatalogueData::unlocked,
+            PacketCodecs.VAR_INT,
+            CatalogueData::normalBookshelves,
+            CatalogueData::new
+    );
+}

--- a/src/main/java/com/akitain/enchantmentoverhaul/enchant/CatalogueScreenHandler.java
+++ b/src/main/java/com/akitain/enchantmentoverhaul/enchant/CatalogueScreenHandler.java
@@ -1,0 +1,215 @@
+package com.akitain.enchantmentoverhaul.enchant;
+
+import net.minecraft.block.Blocks;
+import net.minecraft.component.DataComponentTypes;
+import net.minecraft.component.type.ItemEnchantmentsComponent;
+import net.minecraft.enchantment.Enchantment;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.inventory.Inventory;
+import net.minecraft.inventory.SimpleInventory;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+import net.minecraft.registry.DynamicRegistryManager;
+import net.minecraft.registry.RegistryKey;
+import net.minecraft.registry.RegistryKeys;
+import net.minecraft.registry.entry.RegistryEntry;
+import net.minecraft.screen.ScreenHandler;
+import net.minecraft.screen.ScreenHandlerContext;
+import net.minecraft.screen.slot.Slot;
+import net.minecraft.util.Identifier;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+public class CatalogueScreenHandler extends ScreenHandler {
+
+    public static final int ENCHANT_BUTTON_ID = 1000;
+
+    private final Inventory inventory = new SimpleInventory(3) {
+        @Override
+        public void markDirty() {
+            super.markDirty();
+            CatalogueScreenHandler.this.onContentChanged(this);
+        }
+    };
+
+    private final ScreenHandlerContext context;
+    private final DynamicRegistryManager registryManager;
+    private final Set<Identifier> unlockedIds;
+    private final int normalBookshelves;
+
+    private List<CatalogueEntry> entries = List.of();
+    private int selectedIndex = -1;
+    private int selectedLevel = 1;
+
+    public static CatalogueScreenHandler fromData(int syncId, PlayerInventory playerInventory, CatalogueData data) {
+        return new CatalogueScreenHandler(syncId, playerInventory, ScreenHandlerContext.EMPTY, data.unlocked(), data.normalBookshelves());
+    }
+
+    public CatalogueScreenHandler(int syncId, PlayerInventory playerInventory, ScreenHandlerContext context,
+                                   List<Identifier> unlocked, int normalBookshelves) {
+        super(ModScreenHandlers.CATALOGUE, syncId);
+        this.context = context;
+        this.registryManager = playerInventory.player.getRegistryManager();
+        this.unlockedIds = Set.copyOf(unlocked);
+        this.normalBookshelves = normalBookshelves;
+
+        this.addSlot(new Slot(this.inventory, 0, 18, 22) {
+            @Override
+            public int getMaxItemCount() { return 1; }
+        });
+        this.addSlot(new Slot(this.inventory, 1, 18, 48) {
+            @Override
+            public boolean canInsert(ItemStack stack) { return stack.isOf(Items.LAPIS_LAZULI); }
+        });
+        this.addSlot(new Slot(this.inventory, 2, 18, 74));
+        this.addPlayerSlots(playerInventory, 59, 148);
+    }
+
+    @Override
+    public void onContentChanged(Inventory inv) {
+        if (inv != this.inventory) return;
+        this.selectedIndex = -1;
+        this.selectedLevel = 1;
+        rebuildEntries();
+    }
+
+    public void rebuildEntries() {
+        ItemStack item = this.inventory.getStack(0);
+        if (item.isEmpty()) {
+            this.entries = List.of();
+            return;
+        }
+
+        List<CatalogueEntry> result = new ArrayList<>();
+        var registry = registryManager.getOrThrow(RegistryKeys.ENCHANTMENT);
+        ItemEnchantmentsComponent existing = item.getOrDefault(DataComponentTypes.ENCHANTMENTS, ItemEnchantmentsComponent.DEFAULT);
+
+        for (RegistryEntry<Enchantment> entry : registry.getIndexedEntries()) {
+            Optional<RegistryKey<Enchantment>> keyOpt = entry.getKey();
+            if (keyOpt.isEmpty()) continue;
+
+            RegistryKey<Enchantment> key = keyOpt.get();
+            if (DisabledEnchantments.isDisabled(entry)) continue;
+            if (!entry.value().isAcceptableItem(item)) continue;
+            if (existing.getEnchantments().contains(entry)) continue;
+
+            if (!unlockedIds.contains(key.getValue())) continue;
+
+            int maxLevel = entry.value().getMaxLevel();
+            result.add(new CatalogueEntry(entry, key, maxLevel));
+        }
+
+        this.entries = result;
+    }
+
+    @Override
+    public boolean onButtonClick(PlayerEntity player, int id) {
+        if (id == ENCHANT_BUTTON_ID) return tryEnchant(player);
+
+        if (id >= 0 && id < 1000) {
+            int index = id / 10;
+            int level = (id % 10) + 1;
+            if (index < entries.size()) {
+                this.selectedIndex = index;
+                this.selectedLevel = Math.min(level, entries.get(index).maxLevel());
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean tryEnchant(PlayerEntity player) {
+        if (selectedIndex < 0 || selectedIndex >= entries.size()) return false;
+
+        CatalogueEntry entry = entries.get(selectedIndex);
+
+        RegistryKey<Enchantment> key = entry.key();
+        int level = Math.min(selectedLevel, entry.maxLevel());
+
+        int lapisNeeded = EnchantmentCosts.lapisCost(level);
+        int reagentNeeded = EnchantmentCosts.reagentCost(level, normalBookshelves);
+        int xpNeeded = EnchantmentCosts.xpCost(key, level);
+        int slotsNeeded = EnchantmentCosts.slotCost(key, level);
+
+        ItemStack item = this.inventory.getStack(0);
+        ItemStack lapis = this.inventory.getStack(1);
+        ItemStack reagent = this.inventory.getStack(2);
+
+        if (!canAfford(player, item, lapis, reagent, key, lapisNeeded, reagentNeeded, xpNeeded, slotsNeeded))
+            return false;
+
+        item.addEnchantment(entry.entry(), level);
+
+        if (!player.isCreative()) {
+            lapis.decrement(lapisNeeded);
+            reagent.decrement(reagentNeeded);
+            player.addExperienceLevels(-xpNeeded);
+        }
+
+        this.selectedIndex = -1;
+        this.selectedLevel = 1;
+        rebuildEntries();
+        this.sendContentUpdates();
+        return true;
+    }
+
+    private boolean canAfford(PlayerEntity player, ItemStack item, ItemStack lapis, ItemStack reagent,
+                               RegistryKey<Enchantment> key, int lapisNeeded, int reagentNeeded, int xpNeeded, int slotsNeeded) {
+        if (player.isCreative()) return true;
+        if (lapis.getCount() < lapisNeeded) return false;
+        if (reagent.getCount() < reagentNeeded) return false;
+        if (!reagent.isOf(EnchantmentCosts.reagent(key))) return false;
+        if (player.experienceLevel < xpNeeded) return false;
+        return SlotSystem.getAvailableSlots(item) >= slotsNeeded;
+    }
+
+    @Override
+    public ItemStack quickMove(PlayerEntity player, int slotIndex) {
+        Slot slot = this.slots.get(slotIndex);
+        if (!slot.hasStack()) return ItemStack.EMPTY;
+
+        ItemStack stack = slot.getStack();
+        ItemStack copy = stack.copy();
+
+        if (slotIndex < 3) {
+            if (!this.insertItem(stack, 3, 39, true)) return ItemStack.EMPTY;
+        } else if (stack.isOf(Items.LAPIS_LAZULI)) {
+            if (!this.insertItem(stack, 1, 2, false)) return ItemStack.EMPTY;
+        } else {
+            if (!this.insertItem(stack, 0, 1, false)) return ItemStack.EMPTY;
+        }
+
+        if (stack.isEmpty()) slot.setStack(ItemStack.EMPTY);
+        else slot.markDirty();
+
+        return stack.getCount() == copy.getCount() ? ItemStack.EMPTY : copy;
+    }
+
+    @Override
+    public void onClosed(PlayerEntity player) {
+        super.onClosed(player);
+        this.context.run((world, pos) -> this.dropInventory(player, this.inventory));
+    }
+
+    @Override
+    public boolean canUse(PlayerEntity player) {
+        return canUse(this.context, player, Blocks.ENCHANTING_TABLE);
+    }
+
+    public List<CatalogueEntry> getEntries() { return entries; }
+    public int getSelectedIndex() { return selectedIndex; }
+    public int getSelectedLevel() { return selectedLevel; }
+    public int getNormalBookshelves() { return normalBookshelves; }
+    public Set<Identifier> getUnlockedIds() { return unlockedIds; }
+
+    public void setSelection(int index, int level) {
+        this.selectedIndex = index;
+        this.selectedLevel = level;
+    }
+
+    public record CatalogueEntry(RegistryEntry<Enchantment> entry, RegistryKey<Enchantment> key, int maxLevel) {}
+}

--- a/src/main/java/com/akitain/enchantmentoverhaul/enchant/EnchantmentCosts.java
+++ b/src/main/java/com/akitain/enchantmentoverhaul/enchant/EnchantmentCosts.java
@@ -1,0 +1,77 @@
+package com.akitain.enchantmentoverhaul.enchant;
+
+import net.minecraft.enchantment.Enchantment;
+import net.minecraft.enchantment.Enchantments;
+import net.minecraft.item.Item;
+import net.minecraft.item.Items;
+import net.minecraft.registry.RegistryKey;
+
+import java.util.Map;
+
+import static java.util.Map.entry;
+
+public class EnchantmentCosts {
+
+    private static final Map<RegistryKey<Enchantment>, Item> REAGENTS = Map.ofEntries(
+            entry(Enchantments.FIRE_ASPECT, Items.BLAZE_POWDER),
+            entry(Enchantments.FLAME, Items.BLAZE_POWDER),
+            entry(Enchantments.CHANNELING, Items.LIGHTNING_ROD),
+            entry(Enchantments.FROST_WALKER, Items.PACKED_ICE),
+            entry(Enchantments.THORNS, Items.CACTUS),
+            entry(Enchantments.FORTUNE, Items.EMERALD),
+            entry(Enchantments.LOOTING, Items.RABBIT_FOOT),
+            entry(Enchantments.SILK_TOUCH, Items.COBWEB),
+            entry(Enchantments.LUCK_OF_THE_SEA, Items.NAUTILUS_SHELL),
+            entry(Enchantments.INFINITY, Items.SPECTRAL_ARROW),
+            entry(Enchantments.DEPTH_STRIDER, Items.PRISMARINE_SHARD),
+            entry(Enchantments.SOUL_SPEED, Items.SOUL_SAND),
+            entry(Enchantments.SWIFT_SNEAK, Items.ECHO_SHARD),
+            entry(Enchantments.RIPTIDE, Items.HEART_OF_THE_SEA),
+            entry(Enchantments.LOYALTY, Items.IRON_CHAIN),
+            entry(Enchantments.MULTISHOT, Items.FIREWORK_ROCKET),
+            entry(Enchantments.PIERCING, Items.ARROW),
+            entry(Enchantments.WIND_BURST, Items.BREEZE_ROD),
+            entry(Enchantments.RESPIRATION, Items.PUFFERFISH),
+            entry(Enchantments.AQUA_AFFINITY, Items.PRISMARINE_CRYSTALS),
+            entry(Enchantments.SWEEPING_EDGE, Items.IRON_NUGGET),
+            entry(Enchantments.BREACH, Items.BREEZE_ROD),
+            entry(Enchantments.KNOCKBACK, Items.PISTON),
+            entry(Enchantments.LUNGE, Items.SLIME_BALL),
+            entry(Enchantments.FEATHER_FALLING, Items.FEATHER),
+            entry(Enchantments.QUICK_CHARGE, Items.STRING),
+            entry(Enchantments.LURE, Items.TROPICAL_FISH),
+            entry(Enchantments.MENDING, Items.AMETHYST_SHARD),
+            entry(Enchantments.BINDING_CURSE, Items.IRON_CHAIN),
+            entry(Enchantments.VANISHING_CURSE, Items.PHANTOM_MEMBRANE)
+    );
+
+    private static final int[] XP_BY_LEVEL = {0, 2, 4, 7, 10};
+
+    public static Item reagent(RegistryKey<Enchantment> key) {
+        return REAGENTS.getOrDefault(key, Items.LAPIS_LAZULI);
+    }
+
+    public static int lapisCost(int level) {
+        return level;
+    }
+
+    public static int baseReagentCost(int level) {
+        return level * 2;
+    }
+
+    public static int reagentCost(int level, int normalBookshelves) {
+        double discount = BookshelfScanner.reagentDiscount(normalBookshelves);
+        return Math.max(1, (int) Math.ceil(baseReagentCost(level) * (1.0 - discount)));
+    }
+
+    public static int xpCost(RegistryKey<Enchantment> key, int level) {
+        if (key.equals(Enchantments.MENDING)) return 8;
+        if (level >= XP_BY_LEVEL.length) return XP_BY_LEVEL[XP_BY_LEVEL.length - 1];
+        return XP_BY_LEVEL[level];
+    }
+
+    public static int slotCost(RegistryKey<Enchantment> key, int level) {
+        if (key.equals(Enchantments.MENDING)) return 3;
+        return level;
+    }
+}

--- a/src/main/java/com/akitain/enchantmentoverhaul/enchant/ModScreenHandlers.java
+++ b/src/main/java/com/akitain/enchantmentoverhaul/enchant/ModScreenHandlers.java
@@ -1,0 +1,17 @@
+package com.akitain.enchantmentoverhaul.enchant;
+
+import com.akitain.enchantmentoverhaul.EnchantmentOverhaul;
+import net.fabricmc.fabric.api.screenhandler.v1.ExtendedScreenHandlerType;
+import net.minecraft.registry.Registries;
+import net.minecraft.registry.Registry;
+import net.minecraft.util.Identifier;
+
+public class ModScreenHandlers {
+
+    public static final ExtendedScreenHandlerType<CatalogueScreenHandler, CatalogueData> CATALOGUE =
+            new ExtendedScreenHandlerType<>(CatalogueScreenHandler::fromData, CatalogueData.PACKET_CODEC);
+
+    public static void register() {
+        Registry.register(Registries.SCREEN_HANDLER, Identifier.of(EnchantmentOverhaul.MOD_ID, "catalogue"), CATALOGUE);
+    }
+}

--- a/src/main/java/com/akitain/enchantmentoverhaul/mixin/EnchantingTableBlockMixin.java
+++ b/src/main/java/com/akitain/enchantmentoverhaul/mixin/EnchantingTableBlockMixin.java
@@ -1,0 +1,69 @@
+package com.akitain.enchantmentoverhaul.mixin;
+
+import com.akitain.enchantmentoverhaul.enchant.BookshelfScanner;
+import com.akitain.enchantmentoverhaul.enchant.CatalogueData;
+import com.akitain.enchantmentoverhaul.enchant.CatalogueScreenHandler;
+import net.fabricmc.fabric.api.screenhandler.v1.ExtendedScreenHandlerFactory;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.EnchantingTableBlock;
+import net.minecraft.block.entity.EnchantingTableBlockEntity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.registry.RegistryKey;
+import net.minecraft.screen.ScreenHandler;
+import net.minecraft.screen.ScreenHandlerContext;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.text.Text;
+import net.minecraft.util.ActionResult;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.hit.BlockHitResult;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.List;
+
+@Mixin(EnchantingTableBlock.class)
+public class EnchantingTableBlockMixin {
+
+    @Inject(method = "onUse", at = @At("HEAD"), cancellable = true)
+    private void openCatalogue(BlockState state, World world, BlockPos pos, PlayerEntity player, BlockHitResult hit, CallbackInfoReturnable<ActionResult> cir) {
+        if (world.isClient()) {
+            cir.setReturnValue(ActionResult.SUCCESS);
+            return;
+        }
+
+        if (!(player instanceof ServerPlayerEntity serverPlayer)) return;
+
+        BookshelfScanner.ScanResult scan = BookshelfScanner.scan(world, pos);
+        List<Identifier> unlocked = scan.unlocked().stream()
+                .map(RegistryKey::getValue)
+                .toList();
+        int bookshelves = scan.normalBookshelves();
+        Text title = world.getBlockEntity(pos) instanceof EnchantingTableBlockEntity entity
+                ? entity.getDisplayName()
+                : Text.translatable("container.enchant");
+
+        serverPlayer.openHandledScreen(new ExtendedScreenHandlerFactory<CatalogueData>() {
+            @Override
+            public CatalogueData getScreenOpeningData(ServerPlayerEntity p) {
+                return new CatalogueData(unlocked, bookshelves);
+            }
+
+            @Override
+            public Text getDisplayName() {
+                return title;
+            }
+
+            @Override
+            public ScreenHandler createMenu(int syncId, PlayerInventory inv, PlayerEntity p) {
+                return new CatalogueScreenHandler(syncId, inv, ScreenHandlerContext.create(world, pos), unlocked, bookshelves);
+            }
+        });
+
+        cir.setReturnValue(ActionResult.SUCCESS);
+    }
+}

--- a/src/main/java/com/akitain/enchantmentoverhaul/mixin/EnchantmentNameMixin.java
+++ b/src/main/java/com/akitain/enchantmentoverhaul/mixin/EnchantmentNameMixin.java
@@ -3,6 +3,7 @@ package com.akitain.enchantmentoverhaul.mixin;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.registry.entry.RegistryEntry;
 import net.minecraft.registry.tag.EnchantmentTags;
+import net.minecraft.screen.ScreenTexts;
 import net.minecraft.text.MutableText;
 import net.minecraft.text.Style;
 import net.minecraft.text.Text;
@@ -17,9 +18,14 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 public class EnchantmentNameMixin {
 
     @Inject(method = "getName", at = @At("HEAD"), cancellable = true)
-    private static void removeLevelSuffix(RegistryEntry<Enchantment> enchantment, int level, CallbackInfoReturnable<Text> cir) {
+    private static void hideLevelOneOnly(RegistryEntry<Enchantment> enchantment, int level, CallbackInfoReturnable<Text> cir) {
         Formatting color = enchantment.isIn(EnchantmentTags.CURSE) ? Formatting.RED : Formatting.GRAY;
         MutableText name = Texts.setStyleIfAbsent(enchantment.value().description().copy(), Style.EMPTY.withColor(color));
+
+        if (level > 1) {
+            name.append(ScreenTexts.SPACE).append(Text.translatable("enchantment.level." + level));
+        }
+
         cir.setReturnValue(name);
     }
 }

--- a/src/main/java/com/akitain/enchantmentoverhaul/mixin/GrindstoneScreenHandlerMixin.java
+++ b/src/main/java/com/akitain/enchantmentoverhaul/mixin/GrindstoneScreenHandlerMixin.java
@@ -1,0 +1,21 @@
+package com.akitain.enchantmentoverhaul.mixin;
+
+import com.akitain.enchantmentoverhaul.component.ModComponents;
+import net.minecraft.item.ItemStack;
+import net.minecraft.screen.GrindstoneScreenHandler;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(GrindstoneScreenHandler.class)
+public class GrindstoneScreenHandlerMixin {
+
+    @Inject(method = "grind", at = @At("RETURN"))
+    private void applySlotPenalty(ItemStack item, CallbackInfoReturnable<ItemStack> cir) {
+        ItemStack result = cir.getReturnValue();
+        if (result.isEmpty()) return;
+        int penalty = result.getOrDefault(ModComponents.GRINDSTONE_PENALTY, 0);
+        result.set(ModComponents.GRINDSTONE_PENALTY, penalty + 1);
+    }
+}

--- a/src/main/java/com/akitain/enchantmentoverhaul/mixin/GrindstoneScreenHandlerMixin.java
+++ b/src/main/java/com/akitain/enchantmentoverhaul/mixin/GrindstoneScreenHandlerMixin.java
@@ -1,6 +1,7 @@
 package com.akitain.enchantmentoverhaul.mixin;
 
 import com.akitain.enchantmentoverhaul.component.ModComponents;
+import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.item.ItemStack;
 import net.minecraft.screen.GrindstoneScreenHandler;
 import org.spongepowered.asm.mixin.Mixin;
@@ -15,6 +16,9 @@ public class GrindstoneScreenHandlerMixin {
     private void applySlotPenalty(ItemStack item, CallbackInfoReturnable<ItemStack> cir) {
         ItemStack result = cir.getReturnValue();
         if (result.isEmpty()) return;
+
+        EnchantmentHelper.apply(result, components -> components.remove(enchantment -> true));
+
         int penalty = result.getOrDefault(ModComponents.GRINDSTONE_PENALTY, 0);
         result.set(ModComponents.GRINDSTONE_PENALTY, penalty + 1);
     }

--- a/src/main/resources/enchantment-overhaul.mixins.json
+++ b/src/main/resources/enchantment-overhaul.mixins.json
@@ -11,7 +11,8 @@
         "EnchantBookFactoryMixin",
         "EnchantmentNameMixin",
         "ItemGroupsMixin",
-        "EnchantingTableBlockMixin"
+        "EnchantingTableBlockMixin",
+        "GrindstoneScreenHandlerMixin"
     ],
     "client": [],
     "injectors": {

--- a/src/main/resources/enchantment-overhaul.mixins.json
+++ b/src/main/resources/enchantment-overhaul.mixins.json
@@ -10,7 +10,8 @@
         "MobEntityMixin",
         "EnchantBookFactoryMixin",
         "EnchantmentNameMixin",
-        "ItemGroupsMixin"
+        "ItemGroupsMixin",
+        "EnchantingTableBlockMixin"
     ],
     "client": [],
     "injectors": {


### PR DESCRIPTION
## Summary

Replaces the vanilla enchanting table with a catalogue UI backed by chiseled bookshelf detection — only enchantments present in nearby chiseled bookshelves are available. Normal bookshelves provide a reagent discount (up to 50% at 15). The grindstone now removes all enchantments including curses and applies a permanent -1 max slot penalty per use. Enchantment level display is cleaned up: level 1 is hidden, level 2+ shown normally.

Closes #12, closes #13, closes #14, closes #22.