### PR TITLE
feat: smithing templates and enchanting UI overhaul

### DIFF
--- a/src/main/java/com/akitain/enchantmentoverhaul/EnchantmentOverhaul.java
+++ b/src/main/java/com/akitain/enchantmentoverhaul/EnchantmentOverhaul.java
@@ -2,6 +2,7 @@ package com.akitain.enchantmentoverhaul;
 
 import com.akitain.enchantmentoverhaul.component.ModComponents;
 import com.akitain.enchantmentoverhaul.enchant.ModScreenHandlers;
+import com.akitain.enchantmentoverhaul.smithing.SmithingTemplates;
 import net.fabricmc.api.ModInitializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -15,6 +16,7 @@ public class EnchantmentOverhaul implements ModInitializer {
     public void onInitialize() {
         ModComponents.register();
         ModScreenHandlers.register();
+        SmithingTemplates.register();
         LOGGER.info("Enchantment Overhaul loaded");
     }
 }

--- a/src/main/java/com/akitain/enchantmentoverhaul/EnchantmentOverhaul.java
+++ b/src/main/java/com/akitain/enchantmentoverhaul/EnchantmentOverhaul.java
@@ -4,6 +4,9 @@ import com.akitain.enchantmentoverhaul.component.ModComponents;
 import com.akitain.enchantmentoverhaul.enchant.ModScreenHandlers;
 import com.akitain.enchantmentoverhaul.smithing.SmithingTemplates;
 import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.itemgroup.v1.ItemGroupEvents;
+import net.minecraft.item.ItemGroups;
+import net.minecraft.item.ItemStack;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -17,6 +20,14 @@ public class EnchantmentOverhaul implements ModInitializer {
         ModComponents.register();
         ModScreenHandlers.register();
         SmithingTemplates.register();
+
+        ItemGroupEvents.modifyEntriesEvent(ItemGroups.INGREDIENTS).register(entries -> {
+            entries.add(new ItemStack(SmithingTemplates.HONING_TEMPLATE));
+            entries.add(new ItemStack(SmithingTemplates.WARDING_TEMPLATE));
+            entries.add(new ItemStack(SmithingTemplates.TEMPERING_TEMPLATE));
+            entries.add(new ItemStack(SmithingTemplates.GRINDING_TEMPLATE));
+        });
+
         LOGGER.info("Enchantment Overhaul loaded");
     }
 }

--- a/src/main/java/com/akitain/enchantmentoverhaul/EnchantmentOverhaulClient.java
+++ b/src/main/java/com/akitain/enchantmentoverhaul/EnchantmentOverhaulClient.java
@@ -3,6 +3,7 @@ package com.akitain.enchantmentoverhaul;
 import com.akitain.enchantmentoverhaul.client.CatalogueScreen;
 import com.akitain.enchantmentoverhaul.enchant.ModScreenHandlers;
 import com.akitain.enchantmentoverhaul.enchant.SlotSystem;
+import com.akitain.enchantmentoverhaul.smithing.UpgradeType;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.item.v1.ItemTooltipCallback;
 import net.minecraft.client.gui.screen.ingame.HandledScreens;
@@ -17,9 +18,22 @@ public class EnchantmentOverhaulClient implements ClientModInitializer {
         HandledScreens.register(ModScreenHandlers.CATALOGUE, CatalogueScreen::new);
 
         ItemTooltipCallback.EVENT.register((stack, context, type, lines) -> {
+            addUpgradeLines(stack, lines);
             if (SlotSystem.getBaseMaxSlots(stack) <= 0) return;
             lines.add(Text.literal(slotText(stack)).formatted(slotColor(stack)));
         });
+    }
+
+    private static final String[] ROMAN = {"", "I", "II", "III", "IV", "V"};
+
+    private static void addUpgradeLines(ItemStack stack, java.util.List<Text> lines) {
+        for (UpgradeType type : UpgradeType.values()) {
+            int level = type.currentLevel(stack);
+            if (level <= 0) continue;
+            String name = type.name().charAt(0) + type.name().substring(1).toLowerCase();
+            String roman = level >= 1 && level <= 5 ? ROMAN[level] : String.valueOf(level);
+            lines.add(Text.literal(name + " " + roman).formatted(Formatting.BLUE));
+        }
     }
 
     private static String slotText(ItemStack stack) {

--- a/src/main/java/com/akitain/enchantmentoverhaul/client/CatalogueScreen.java
+++ b/src/main/java/com/akitain/enchantmentoverhaul/client/CatalogueScreen.java
@@ -346,13 +346,13 @@ public class CatalogueScreen extends HandledScreen<CatalogueScreenHandler> {
         ItemStack lapis = handler.getSlot(1).getStack();
         ItemStack reagent = handler.getSlot(2).getStack();
 
+        if (SlotSystem.getAvailableSlots(item) < EnchantmentCosts.slotCost(key, level)) return false;
         if (MinecraftClient.getInstance().player.isCreative()) return true;
 
         return lapis.getCount() >= EnchantmentCosts.lapisCost(level)
                 && reagent.isOf(EnchantmentCosts.reagent(key))
                 && reagent.getCount() >= EnchantmentCosts.reagentCost(level, handler.getNormalBookshelves())
-                && MinecraftClient.getInstance().player.experienceLevel >= EnchantmentCosts.xpCost(key, level)
-                && SlotSystem.getAvailableSlots(item) >= EnchantmentCosts.slotCost(key, level);
+                && MinecraftClient.getInstance().player.experienceLevel >= EnchantmentCosts.xpCost(key, level);
     }
 
     // --- Input ---

--- a/src/main/java/com/akitain/enchantmentoverhaul/client/CatalogueScreen.java
+++ b/src/main/java/com/akitain/enchantmentoverhaul/client/CatalogueScreen.java
@@ -37,38 +37,45 @@ public class CatalogueScreen extends HandledScreen<CatalogueScreenHandler> {
     private static final int BG_H = 230;
 
     private static final int CAT_X = 52;
-    private static final int CAT_Y = 20;
-    private static final int CAT_W = 216;
+    private static final int CAT_Y = 18;
+    private static final int CAT_W = 220;
     private static final int ROW_H = 20;
     private static final int VISIBLE_ROWS = 5;
     private static final int CAT_H = ROW_H * VISIBLE_ROWS;
-
     private static final int SCROLLBAR_W = 6;
 
-    private static final int BTN_X = 8;
+    private static final int BTN_X = 6;
     private static final int BTN_Y = 108;
-    private static final int BTN_W = 36;
+    private static final int BTN_W = 38;
     private static final int BTN_H = 14;
 
-    private static final int SLOT_BAR_Y = 126;
+    private static final int SLOT_BAR_Y = 124;
 
-    private static final int PURPLE_DARK = 0xFF1A0A2E;
+    // Vanilla-inspired row colors
+    private static final int ROW_BG = 0xFF56493D;
+    private static final int ROW_HOVER = 0xFF6B5D4E;
+    private static final int ROW_SELECTED = 0xFF80507A;
+    private static final int ROW_BORDER_L = 0xFF7A6B5A;
+    private static final int ROW_BORDER_D = 0xFF3A3028;
+
+    // General colors
+    private static final int PANEL_BG = 0xFF1A0A2E;
     private static final int PURPLE_MID = 0xFF2D1250;
     private static final int PURPLE_LIGHT = 0xFF8050C0;
     private static final int PURPLE_BRIGHT = 0xFFC080FF;
     private static final int TEXT_LIGHT = 0xFFE0D8F0;
     private static final int TEXT_DIM = 0xFF9080B0;
-    private static final int GREEN = 0xFF55FF55;
-    private static final int RED = 0xFFFF5555;
     private static final int GOLD = 0xFFFFAA00;
     private static final int BG = 0xFFC6C6C6;
-    private static final Style SGA_STYLE = Style.EMPTY.withFont(new StyleSpriteSource.Font(Identifier.of("minecraft", "alt"))).withColor(0x6040A0);
     private static final int SLOT_BG = 0xFF8B8B8B;
     private static final int BORDER_L = 0xFFFFFFFF;
     private static final int BORDER_D = 0xFF555555;
 
+    private static final Style SGA_STYLE = Style.EMPTY
+            .withFont(new StyleSpriteSource.Font(Identifier.of("minecraft", "alt")));
     private static final String SGA_CHARS = "abcdefghijklmnopqrstuvwxyz";
-    private String sgaLine = randomSga(40);
+
+    private final String[] sgaRows = new String[20];
 
     private float scrollAmount;
     private int scrollOffset;
@@ -83,6 +90,7 @@ public class CatalogueScreen extends HandledScreen<CatalogueScreenHandler> {
         this.titleY = 6;
         this.playerInventoryTitleX = 59;
         this.playerInventoryTitleY = BG_H - 94;
+        for (int i = 0; i < sgaRows.length; i++) sgaRows[i] = randomSga(28);
     }
 
     @Override
@@ -109,6 +117,8 @@ public class CatalogueScreen extends HandledScreen<CatalogueScreenHandler> {
         }
     }
 
+    // --- Drawing ---
+
     @Override
     protected void drawBackground(DrawContext context, float deltaTicks, int mouseX, int mouseY) {
         int x = this.x, y = this.y;
@@ -116,12 +126,48 @@ public class CatalogueScreen extends HandledScreen<CatalogueScreenHandler> {
         context.fill(x, y, x + BG_W, y + BG_H, BG);
         border3D(context, x, y, BG_W, BG_H, BORDER_L, BORDER_D);
 
+        drawBook(context, x, y);
         drawInputSlots(context, x, y);
         drawCatalogue(context, x, y, mouseX, mouseY);
-        drawSgaDecoration(context, x, y);
         drawSlotBar(context, x, y);
         drawEnchantButton(context, x, y, mouseX, mouseY);
         drawPlayerSlotBorders(context, x, y);
+    }
+
+    @Override
+    protected void drawForeground(DrawContext context, int mouseX, int mouseY) {
+        context.drawText(textRenderer, Text.literal("Enchant"), titleX, titleY, 0x404040, false);
+        context.drawText(textRenderer, this.playerInventoryTitle, playerInventoryTitleX, playerInventoryTitleY, 0x404040, false);
+    }
+
+    private void drawBook(DrawContext context, int x, int y) {
+        int bx = x + 10, by = y + 18;
+        // Spine
+        context.fill(bx + 15, by, bx + 17, by + 22, 0xFF5C3A1E);
+        // Left page
+        context.fill(bx + 2, by + 1, bx + 15, by + 21, 0xFFD8C8A0);
+        context.fill(bx + 1, by + 2, bx + 2, by + 20, 0xFFD8C8A0);
+        // Right page
+        context.fill(bx + 17, by + 1, bx + 30, by + 21, 0xFFD8C8A0);
+        context.fill(bx + 30, by + 2, bx + 31, by + 20, 0xFFD8C8A0);
+        // Left cover edges
+        context.fill(bx, by + 2, bx + 1, by + 20, 0xFF8B5A2B);
+        context.fill(bx + 1, by, bx + 15, by + 1, 0xFF8B5A2B);
+        context.fill(bx + 1, by + 21, bx + 15, by + 22, 0xFF6B3A1B);
+        // Right cover edges
+        context.fill(bx + 31, by + 2, bx + 32, by + 20, 0xFF8B5A2B);
+        context.fill(bx + 17, by, bx + 31, by + 1, 0xFF8B5A2B);
+        context.fill(bx + 17, by + 21, bx + 31, by + 22, 0xFF6B3A1B);
+        // Page lines (left)
+        for (int i = 0; i < 4; i++) {
+            int ly = by + 5 + i * 4;
+            context.fill(bx + 4, ly, bx + 13, ly + 1, 0x30000000);
+        }
+        // Page lines (right)
+        for (int i = 0; i < 4; i++) {
+            int ly = by + 5 + i * 4;
+            context.fill(bx + 19, ly, bx + 28, ly + 1, 0x30000000);
+        }
     }
 
     private void drawInputSlots(DrawContext context, int x, int y) {
@@ -131,27 +177,11 @@ public class CatalogueScreen extends HandledScreen<CatalogueScreenHandler> {
         }
     }
 
-    @Override
-    protected void drawForeground(DrawContext context, int mouseX, int mouseY) {
-        context.drawText(textRenderer, this.title, titleX, titleY, 0x404040, false);
-
-        Slot s0 = handler.slots.get(0);
-        Slot s1 = handler.slots.get(1);
-        Slot s2 = handler.slots.get(2);
-        context.drawText(textRenderer, "Item", s0.x - 1, s0.y + 18, TEXT_DIM, true);
-        context.drawText(textRenderer, "Lapis", s1.x - 1, s1.y + 18, TEXT_DIM, true);
-        context.drawText(textRenderer, "Reagent", s2.x - 4, s2.y + 18, TEXT_DIM, true);
-
-        context.drawText(textRenderer, this.playerInventoryTitle, playerInventoryTitleX, playerInventoryTitleY, 0x404040, false);
-    }
-
     private void drawCatalogue(DrawContext context, int x, int y, int mouseX, int mouseY) {
         int cx = x + CAT_X, cy = y + CAT_Y;
 
-        context.fill(cx, cy, cx + CAT_W, cy + CAT_H, PURPLE_DARK);
+        context.fill(cx, cy, cx + CAT_W, cy + CAT_H, PANEL_BG);
         borderInset(context, cx, cy, CAT_W, CAT_H);
-
-        context.drawTextWithShadow(textRenderer, "Catalogue", cx, cy - 12, TEXT_LIGHT);
 
         List<CatalogueEntry> entries = handler.getEntries();
         if (entries.isEmpty()) {
@@ -164,41 +194,54 @@ public class CatalogueScreen extends HandledScreen<CatalogueScreenHandler> {
             return;
         }
 
+        int rowW = CAT_W - SCROLLBAR_W - 4;
         int end = Math.min(scrollOffset + VISIBLE_ROWS, entries.size());
         for (int i = scrollOffset; i < end; i++) {
-            int ry = cy + (i - scrollOffset) * ROW_H;
-            drawRow(context, entries.get(i), i, cx, ry, mouseX, mouseY);
+            int row = i - scrollOffset;
+            int ry = cy + 1 + row * ROW_H;
+            drawRow(context, entries.get(i), i, cx + 1, ry, rowW, mouseX, mouseY);
         }
 
         drawScrollbar(context, cx + CAT_W - SCROLLBAR_W - 1, cy + 1, CAT_H - 2);
     }
 
-    private void drawRow(DrawContext context, CatalogueEntry entry, int idx, int cx, int ry, int mx, int my) {
+    private void drawRow(DrawContext context, CatalogueEntry entry, int idx, int rx, int ry, int rw, int mx, int my) {
         boolean selected = idx == handler.getSelectedIndex();
-        boolean hovered = mx >= cx && mx < cx + CAT_W && my >= ry && my < ry + ROW_H;
+        boolean hovered = mx >= rx && mx < rx + rw && my >= ry && my < ry + ROW_H;
 
-        if (selected) {
-            context.fill(cx + 1, ry, cx + CAT_W - SCROLLBAR_W - 2, ry + ROW_H, 0x50A060FF);
-        } else if (hovered) {
-            context.fill(cx + 1, ry, cx + CAT_W - SCROLLBAR_W - 2, ry + ROW_H, 0x30FFFFFF);
-        }
+        int bg = selected ? ROW_SELECTED : (hovered ? ROW_HOVER : ROW_BG);
+        context.fill(rx, ry, rx + rw, ry + ROW_H - 1, bg);
 
-        int ty = ry + (ROW_H - 8) / 2;
+        // Top/bottom row border
+        int borderTop = selected ? 0xFF9A6090 : ROW_BORDER_L;
+        int borderBot = selected ? 0xFF60305A : ROW_BORDER_D;
+        context.fill(rx, ry, rx + rw, ry + 1, borderTop);
+        context.fill(rx, ry + ROW_H - 2, rx + rw, ry + ROW_H - 1, borderBot);
+
+        // SGA decoration text (subtle behind the name)
+        int sgaColor = selected ? 0xFF9A6898 : 0xFF6B5D50;
+        String sga = sgaRows[idx % sgaRows.length];
+        context.drawText(textRenderer, Text.literal(sga).setStyle(SGA_STYLE), rx + 4, ry + 6, sgaColor, false);
+
+        // Enchantment name overlaid
+        int ty = ry + (ROW_H - 9) / 2;
         boolean curse = entry.entry().isIn(EnchantmentTags.CURSE);
-        int nameColor = curse ? 0xFFFF6666 : TEXT_LIGHT;
+        int nameColor = selected ? 0xFFFFFFFF : (curse ? 0xFFFF6666 : 0xFFE8DCC8);
         String name = entry.entry().value().description().getString();
-        context.drawTextWithShadow(textRenderer, name, cx + 6, ty, nameColor);
+        context.drawTextWithShadow(textRenderer, name, rx + 4, ty, nameColor);
 
-        int lvX = cx + CAT_W - SCROLLBAR_W - 8 - entry.maxLevel() * 14;
+        // Level buttons right-aligned
+        int lvX = rx + rw - 2 - entry.maxLevel() * 14;
         int selLv = selected ? handler.getSelectedLevel() : 0;
 
         for (int lv = 1; lv <= entry.maxLevel(); lv++) {
             boolean lvSel = selected && lv == selLv;
-            int bg = lvSel ? PURPLE_LIGHT : PURPLE_MID;
-            context.fill(lvX, ry + 3, lvX + 12, ry + ROW_H - 3, bg);
+            int lvBg = lvSel ? 0xFF60A040 : (selected ? 0xFF603060 : 0xFF4A3E34);
+            context.fill(lvX, ry + 3, lvX + 12, ry + ROW_H - 4, lvBg);
             String r = toRoman(lv);
             int tw = textRenderer.getWidth(r);
-            context.drawTextWithShadow(textRenderer, r, lvX + (12 - tw) / 2, ty, lvSel ? GOLD : TEXT_DIM);
+            int lvColor = lvSel ? 0xFF80FF40 : (selected ? 0xFFC0A0C0 : 0xFF8A7A6A);
+            context.drawTextWithShadow(textRenderer, r, lvX + (12 - tw) / 2, ty, lvColor);
             lvX += 14;
         }
     }
@@ -303,11 +346,6 @@ public class CatalogueScreen extends HandledScreen<CatalogueScreenHandler> {
         context.drawTextWithShadow(textRenderer, used + "/" + max, sx + totalW + 6, barY, TEXT_LIGHT);
     }
 
-    private void drawSgaDecoration(DrawContext context, int x, int y) {
-        int sgaY = y + CAT_Y + CAT_H + 2;
-        context.drawText(textRenderer, Text.literal(sgaLine).setStyle(SGA_STYLE), x + CAT_X, sgaY, 0x6040A0, false);
-    }
-
     private void drawEnchantButton(DrawContext context, int x, int y, int mx, int my) {
         int bx = x + BTN_X, by = y + BTN_Y;
         boolean can = canEnchantNow();
@@ -339,7 +377,6 @@ public class CatalogueScreen extends HandledScreen<CatalogueScreenHandler> {
         if (handler.getSelectedIndex() >= entries.size()) return false;
 
         CatalogueEntry entry = entries.get(handler.getSelectedIndex());
-
         int level = handler.getSelectedLevel();
         RegistryKey<Enchantment> key = entry.key();
         ItemStack item = handler.getSlot(0).getStack();
@@ -380,14 +417,16 @@ public class CatalogueScreen extends HandledScreen<CatalogueScreenHandler> {
 
     private boolean clickRow(double mx, double my, int x, int y) {
         int cx = x + CAT_X, cy = y + CAT_Y;
-        if (mx < cx || mx >= cx + CAT_W - SCROLLBAR_W || my < cy || my >= cy + CAT_H) return false;
+        int rowW = CAT_W - SCROLLBAR_W - 4;
+        if (mx < cx + 1 || mx >= cx + 1 + rowW || my < cy || my >= cy + CAT_H) return false;
 
         List<CatalogueEntry> entries = handler.getEntries();
         int idx = scrollOffset + (int) (my - cy) / ROW_H;
         if (idx >= entries.size()) return false;
 
         CatalogueEntry entry = entries.get(idx);
-        int lvX = cx + CAT_W - SCROLLBAR_W - 8 - entry.maxLevel() * 14;
+        int rx = cx + 1;
+        int lvX = rx + rowW - 2 - entry.maxLevel() * 14;
         int level = 1;
         if (mx >= lvX) {
             int lvIdx = (int) (mx - lvX) / 14;
@@ -464,9 +503,7 @@ public class CatalogueScreen extends HandledScreen<CatalogueScreenHandler> {
     private static String randomSga(int length) {
         Random rng = new Random();
         StringBuilder sb = new StringBuilder(length);
-        for (int i = 0; i < length; i++) {
-            sb.append(SGA_CHARS.charAt(rng.nextInt(SGA_CHARS.length())));
-        }
+        for (int i = 0; i < length; i++) sb.append(SGA_CHARS.charAt(rng.nextInt(SGA_CHARS.length())));
         return sb.toString();
     }
 

--- a/src/main/java/com/akitain/enchantmentoverhaul/client/CatalogueScreen.java
+++ b/src/main/java/com/akitain/enchantmentoverhaul/client/CatalogueScreen.java
@@ -62,7 +62,7 @@ public class CatalogueScreen extends HandledScreen<CatalogueScreenHandler> {
     private static final int RED = 0xFFFF5555;
     private static final int GOLD = 0xFFFFAA00;
     private static final int BG = 0xFFC6C6C6;
-    private static final Style SGA_STYLE = Style.EMPTY.withFont(new StyleSpriteSource.Font(Identifier.of("minecraft", "alt"))).withColor(0x3A1A5E);
+    private static final Style SGA_STYLE = Style.EMPTY.withFont(new StyleSpriteSource.Font(Identifier.of("minecraft", "alt"))).withColor(0x6040A0);
     private static final int SLOT_BG = 0xFF8B8B8B;
     private static final int BORDER_L = 0xFFFFFFFF;
     private static final int BORDER_D = 0xFF555555;
@@ -118,6 +118,7 @@ public class CatalogueScreen extends HandledScreen<CatalogueScreenHandler> {
 
         drawInputSlots(context, x, y);
         drawCatalogue(context, x, y, mouseX, mouseY);
+        drawSgaDecoration(context, x, y);
         drawSlotBar(context, x, y);
         drawEnchantButton(context, x, y, mouseX, mouseY);
         drawPlayerSlotBorders(context, x, y);
@@ -151,7 +152,6 @@ public class CatalogueScreen extends HandledScreen<CatalogueScreenHandler> {
         borderInset(context, cx, cy, CAT_W, CAT_H);
 
         context.drawTextWithShadow(textRenderer, "Catalogue", cx, cy - 12, TEXT_LIGHT);
-        context.drawText(textRenderer, Text.literal(sgaLine).setStyle(SGA_STYLE), cx + 3, cy + CAT_H - 10, 0x3A1A5E, false);
 
         List<CatalogueEntry> entries = handler.getEntries();
         if (entries.isEmpty()) {
@@ -301,6 +301,11 @@ public class CatalogueScreen extends HandledScreen<CatalogueScreenHandler> {
         }
 
         context.drawTextWithShadow(textRenderer, used + "/" + max, sx + totalW + 6, barY, TEXT_LIGHT);
+    }
+
+    private void drawSgaDecoration(DrawContext context, int x, int y) {
+        int sgaY = y + CAT_Y + CAT_H + 2;
+        context.drawText(textRenderer, Text.literal(sgaLine).setStyle(SGA_STYLE), x + CAT_X, sgaY, 0x6040A0, false);
     }
 
     private void drawEnchantButton(DrawContext context, int x, int y, int mx, int my) {

--- a/src/main/java/com/akitain/enchantmentoverhaul/client/CatalogueScreen.java
+++ b/src/main/java/com/akitain/enchantmentoverhaul/client/CatalogueScreen.java
@@ -10,6 +10,8 @@ import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.Click;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.screen.ingame.HandledScreen;
+import net.minecraft.client.gl.RenderPipelines;
+import net.minecraft.client.render.entity.model.BookModel;
 import net.minecraft.client.sound.PositionedSoundInstance;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.entity.player.PlayerInventory;
@@ -33,43 +35,46 @@ import java.util.Random;
 @Environment(EnvType.CLIENT)
 public class CatalogueScreen extends HandledScreen<CatalogueScreenHandler> {
 
-    private static final int BG_W = 280;
-    private static final int BG_H = 230;
+    private static final int BG_W = 176;
+    private static final int BG_H = 220;
 
-    private static final int CAT_X = 52;
-    private static final int CAT_Y = 18;
-    private static final int CAT_W = 220;
-    private static final int ROW_H = 20;
+    private static final int CAT_X = 56;
+    private static final int CAT_Y = 16;
+    private static final int CAT_W = 114;
+    private static final int ROW_H = 19;
     private static final int VISIBLE_ROWS = 5;
-    private static final int CAT_H = ROW_H * VISIBLE_ROWS;
-    private static final int SCROLLBAR_W = 6;
+    private static final int CAT_H = 106;
+    private static final int SCROLLBAR_W = 7;
 
-    private static final int BTN_X = 6;
-    private static final int BTN_Y = 108;
-    private static final int BTN_W = 38;
-    private static final int BTN_H = 14;
+    private static final int BOOK_X = 3;
+    private static final int BOOK_Y = 16;
+
+    private static final int LV_BTN = 14;
+    private static final int LV_GAP = 1;
 
     private static final int SLOT_BAR_Y = 124;
 
-    // Vanilla-inspired row colors
     private static final int ROW_BG = 0xFF56493D;
     private static final int ROW_HOVER = 0xFF6B5D4E;
     private static final int ROW_SELECTED = 0xFF80507A;
     private static final int ROW_BORDER_L = 0xFF7A6B5A;
     private static final int ROW_BORDER_D = 0xFF3A3028;
 
-    // General colors
-    private static final int PANEL_BG = 0xFF1A0A2E;
-    private static final int PURPLE_MID = 0xFF2D1250;
-    private static final int PURPLE_LIGHT = 0xFF8050C0;
-    private static final int PURPLE_BRIGHT = 0xFFC080FF;
-    private static final int TEXT_LIGHT = 0xFFE0D8F0;
+    private static final int PANEL_BG = 0xFF585858;
+    private static final int TEXT_LIGHT = 0xFFD8C8F0;
     private static final int TEXT_DIM = 0xFF9080B0;
-    private static final int GOLD = 0xFFFFAA00;
     private static final int BG = 0xFFC6C6C6;
     private static final int SLOT_BG = 0xFF8B8B8B;
     private static final int BORDER_L = 0xFFFFFFFF;
-    private static final int BORDER_D = 0xFF555555;
+    private static final int BORDER_D = 0xFF373737;
+    private static final int ARROW_COLOR = 0xFF9E9E9E;
+
+    private static final Identifier SLOT_SWORD = Identifier.ofVanilla("container/slot/sword");
+    private static final Identifier SLOT_LAPIS = Identifier.ofVanilla("container/slot/lapis_lazuli");
+    private static final Identifier SLOT_AMETHYST = Identifier.ofVanilla("container/slot/amethyst_shard");
+    private static final Identifier BOOK_TEXTURE = Identifier.ofVanilla("textures/entity/enchanting_table_book.png");
+
+    private static final Identifier[] SLOT_PLACEHOLDERS = { SLOT_SWORD, SLOT_LAPIS, SLOT_AMETHYST };
 
     private static final Style SGA_STYLE = Style.EMPTY
             .withFont(new StyleSpriteSource.Font(Identifier.of("minecraft", "alt")));
@@ -77,6 +82,7 @@ public class CatalogueScreen extends HandledScreen<CatalogueScreenHandler> {
 
     private final String[] sgaRows = new String[20];
 
+    private BookModel bookModel;
     private float scrollAmount;
     private int scrollOffset;
     private boolean scrolling;
@@ -88,21 +94,23 @@ public class CatalogueScreen extends HandledScreen<CatalogueScreenHandler> {
         this.backgroundHeight = BG_H;
         this.titleX = 8;
         this.titleY = 6;
-        this.playerInventoryTitleX = 59;
-        this.playerInventoryTitleY = BG_H - 94;
-        for (int i = 0; i < sgaRows.length; i++) sgaRows[i] = randomSga(28);
+        this.playerInventoryTitleX = 7;
+        this.playerInventoryTitleY = 130;
+        for (int i = 0; i < sgaRows.length; i++) sgaRows[i] = randomSga(18);
     }
 
     @Override
     protected void init() {
         super.init();
         handler.rebuildEntries();
+        bookModel = new BookModel(BookModel.getTexturedModelData().createModel());
     }
 
     @Override
     public void render(DrawContext context, int mouseX, int mouseY, float deltaTicks) {
         checkItemChanged();
         super.render(context, mouseX, mouseY, deltaTicks);
+        context.drawText(textRenderer, this.title, this.x + titleX, this.y + titleY, 0xFF404040, false);
         drawCatalogueTooltip(context, mouseX, mouseY);
         drawMouseoverTooltip(context, mouseX, mouseY);
     }
@@ -123,58 +131,70 @@ public class CatalogueScreen extends HandledScreen<CatalogueScreenHandler> {
     protected void drawBackground(DrawContext context, float deltaTicks, int mouseX, int mouseY) {
         int x = this.x, y = this.y;
 
-        context.fill(x, y, x + BG_W, y + BG_H, BG);
-        border3D(context, x, y, BG_W, BG_H, BORDER_L, BORDER_D);
-
+        drawRoundedFrame(context, x, y, BG_W, BG_H);
         drawBook(context, x, y);
         drawInputSlots(context, x, y);
+        drawArrow(context, x, y);
+        drawOutputSlot(context, x, y);
         drawCatalogue(context, x, y, mouseX, mouseY);
         drawSlotBar(context, x, y);
-        drawEnchantButton(context, x, y, mouseX, mouseY);
         drawPlayerSlotBorders(context, x, y);
     }
 
     @Override
     protected void drawForeground(DrawContext context, int mouseX, int mouseY) {
-        context.drawText(textRenderer, Text.literal("Enchant"), titleX, titleY, 0x404040, false);
         context.drawText(textRenderer, this.playerInventoryTitle, playerInventoryTitleX, playerInventoryTitleY, 0x404040, false);
     }
 
+    private void drawRoundedFrame(DrawContext ctx, int x, int y, int w, int h) {
+        int L = BORDER_L, D = BORDER_D;
+
+        ctx.fill(x + 2, y + 2, x + w - 2, y + h - 2, BG);
+
+        ctx.fill(x + 1, y, x + w - 1, y + 1, L);
+        ctx.fill(x, y + 1, x + w, y + 2, L);
+
+        ctx.fill(x, y + h - 2, x + w, y + h - 1, D);
+        ctx.fill(x + 1, y + h - 1, x + w - 1, y + h, D);
+
+        ctx.fill(x, y + 1, x + 1, y + h - 1, L);
+        ctx.fill(x + 1, y, x + 2, y + h, L);
+
+        ctx.fill(x + w - 2, y, x + w - 1, y + h, D);
+        ctx.fill(x + w - 1, y + 1, x + w, y + h - 1, D);
+    }
+
     private void drawBook(DrawContext context, int x, int y) {
-        int bx = x + 10, by = y + 18;
-        // Spine
-        context.fill(bx + 15, by, bx + 17, by + 22, 0xFF5C3A1E);
-        // Left page
-        context.fill(bx + 2, by + 1, bx + 15, by + 21, 0xFFD8C8A0);
-        context.fill(bx + 1, by + 2, bx + 2, by + 20, 0xFFD8C8A0);
-        // Right page
-        context.fill(bx + 17, by + 1, bx + 30, by + 21, 0xFFD8C8A0);
-        context.fill(bx + 30, by + 2, bx + 31, by + 20, 0xFFD8C8A0);
-        // Left cover edges
-        context.fill(bx, by + 2, bx + 1, by + 20, 0xFF8B5A2B);
-        context.fill(bx + 1, by, bx + 15, by + 1, 0xFF8B5A2B);
-        context.fill(bx + 1, by + 21, bx + 15, by + 22, 0xFF6B3A1B);
-        // Right cover edges
-        context.fill(bx + 31, by + 2, bx + 32, by + 20, 0xFF8B5A2B);
-        context.fill(bx + 17, by, bx + 31, by + 1, 0xFF8B5A2B);
-        context.fill(bx + 17, by + 21, bx + 31, by + 22, 0xFF6B3A1B);
-        // Page lines (left)
-        for (int i = 0; i < 4; i++) {
-            int ly = by + 5 + i * 4;
-            context.fill(bx + 4, ly, bx + 13, ly + 1, 0x30000000);
-        }
-        // Page lines (right)
-        for (int i = 0; i < 4; i++) {
-            int ly = by + 5 + i * 4;
-            context.fill(bx + 19, ly, bx + 28, ly + 1, 0x30000000);
-        }
+        if (bookModel == null) return;
+        int bx = x + BOOK_X;
+        int by = y + BOOK_Y;
+        context.addBookModel(bookModel, BOOK_TEXTURE, 40.0f, 0.9f, 0.1f,
+                bx, by, bx + 50, by + 40);
     }
 
     private void drawInputSlots(DrawContext context, int x, int y) {
         for (int i = 0; i < 3; i++) {
             Slot slot = handler.slots.get(i);
             slotBorder(context, x + slot.x - 1, y + slot.y - 1);
+            if (slot.getStack().isEmpty()) {
+                context.drawGuiTexture(RenderPipelines.GUI_TEXTURED, SLOT_PLACEHOLDERS[i],
+                        x + slot.x, y + slot.y, 16, 16);
+            }
         }
+    }
+
+    private void drawArrow(DrawContext context, int x, int y) {
+        int cx = x + 28;
+        int ay = y + 98;
+        context.fill(cx - 1, ay, cx + 1, ay + 3, ARROW_COLOR);
+        context.fill(cx - 3, ay + 3, cx + 3, ay + 4, ARROW_COLOR);
+        context.fill(cx - 2, ay + 4, cx + 2, ay + 5, ARROW_COLOR);
+        context.fill(cx - 1, ay + 5, cx + 1, ay + 6, ARROW_COLOR);
+    }
+
+    private void drawOutputSlot(DrawContext context, int x, int y) {
+        Slot slot = handler.slots.get(3);
+        slotBorder(context, x + slot.x - 1, y + slot.y - 1);
     }
 
     private void drawCatalogue(DrawContext context, int x, int y, int mouseX, int mouseY) {
@@ -186,11 +206,17 @@ public class CatalogueScreen extends HandledScreen<CatalogueScreenHandler> {
         List<CatalogueEntry> entries = handler.getEntries();
         if (entries.isEmpty()) {
             String hint = handler.getSlot(0).getStack().isEmpty()
-                    ? "Place an item to enchant"
-                    : "No enchantments unlocked";
-            context.drawTextWithShadow(textRenderer, hint,
-                    cx + (CAT_W - textRenderer.getWidth(hint)) / 2,
-                    cy + CAT_H / 2 - 4, TEXT_DIM);
+                    ? "Insert item"
+                    : "Unlock enchantments with bookshelves";
+            List<net.minecraft.text.OrderedText> lines = textRenderer.wrapLines(Text.literal(hint), CAT_W - 8);
+            int totalH = lines.size() * (textRenderer.fontHeight + 2);
+            int startY = cy + (CAT_H - totalH) / 2;
+            for (int i = 0; i < lines.size(); i++) {
+                int lw = textRenderer.getWidth(lines.get(i));
+                context.drawText(textRenderer, lines.get(i),
+                        cx + (CAT_W - lw) / 2,
+                        startY + i * (textRenderer.fontHeight + 2), 0xFF808080, false);
+            }
             return;
         }
 
@@ -198,11 +224,11 @@ public class CatalogueScreen extends HandledScreen<CatalogueScreenHandler> {
         int end = Math.min(scrollOffset + VISIBLE_ROWS, entries.size());
         for (int i = scrollOffset; i < end; i++) {
             int row = i - scrollOffset;
-            int ry = cy + 1 + row * ROW_H;
-            drawRow(context, entries.get(i), i, cx + 1, ry, rowW, mouseX, mouseY);
+            int ry = cy + 2 + row * (ROW_H + 1);
+            drawRow(context, entries.get(i), i, cx + 2, ry, rowW, mouseX, mouseY);
         }
 
-        drawScrollbar(context, cx + CAT_W - SCROLLBAR_W - 1, cy + 1, CAT_H - 2);
+        drawScrollbar(context, cx + CAT_W - SCROLLBAR_W - 2, cy + 2, CAT_H - 4);
     }
 
     private void drawRow(DrawContext context, CatalogueEntry entry, int idx, int rx, int ry, int rw, int mx, int my) {
@@ -210,39 +236,42 @@ public class CatalogueScreen extends HandledScreen<CatalogueScreenHandler> {
         boolean hovered = mx >= rx && mx < rx + rw && my >= ry && my < ry + ROW_H;
 
         int bg = selected ? ROW_SELECTED : (hovered ? ROW_HOVER : ROW_BG);
-        context.fill(rx, ry, rx + rw, ry + ROW_H - 1, bg);
+        context.fill(rx, ry, rx + rw, ry + ROW_H, bg);
 
-        // Top/bottom row border
         int borderTop = selected ? 0xFF9A6090 : ROW_BORDER_L;
         int borderBot = selected ? 0xFF60305A : ROW_BORDER_D;
         context.fill(rx, ry, rx + rw, ry + 1, borderTop);
-        context.fill(rx, ry + ROW_H - 2, rx + rw, ry + ROW_H - 1, borderBot);
+        context.fill(rx, ry + ROW_H - 1, rx + rw, ry + ROW_H, borderBot);
 
-        // SGA decoration text (subtle behind the name)
-        int sgaColor = selected ? 0xFF9A6898 : 0xFF6B5D50;
+        // Level buttons (right-aligned, drawn first so SGA clips before them)
+        int lvX = rx + rw - 2 - entry.maxLevel() * (LV_BTN + LV_GAP);
+        int sgaMaxX = lvX - 3;
+
+        // SGA gibberish (main row content, clipped before buttons)
+        int sgaColor = selected ? 0xFFE0C0E0 : (hovered ? 0xFFB0A080 : 0xFF988870);
         String sga = sgaRows[idx % sgaRows.length];
-        context.drawText(textRenderer, Text.literal(sga).setStyle(SGA_STYLE), rx + 4, ry + 6, sgaColor, false);
-
-        // Enchantment name overlaid
-        int ty = ry + (ROW_H - 9) / 2;
-        boolean curse = entry.entry().isIn(EnchantmentTags.CURSE);
-        int nameColor = selected ? 0xFFFFFFFF : (curse ? 0xFFFF6666 : 0xFFE8DCC8);
-        String name = entry.entry().value().description().getString();
-        context.drawTextWithShadow(textRenderer, name, rx + 4, ty, nameColor);
-
-        // Level buttons right-aligned
-        int lvX = rx + rw - 2 - entry.maxLevel() * 14;
+        int sgaY = ry + (ROW_H - 8) / 2;
+        Text sgaText = Text.literal(trimToWidth(sga, sgaMaxX - rx - 3)).setStyle(SGA_STYLE);
+        context.drawTextWithShadow(textRenderer, sgaText, rx + 3, sgaY, sgaColor);
         int selLv = selected ? handler.getSelectedLevel() : 0;
 
         for (int lv = 1; lv <= entry.maxLevel(); lv++) {
             boolean lvSel = selected && lv == selLv;
-            int lvBg = lvSel ? 0xFF60A040 : (selected ? 0xFF603060 : 0xFF4A3E34);
-            context.fill(lvX, ry + 3, lvX + 12, ry + ROW_H - 4, lvBg);
+            int lvBg = lvSel ? 0xFF5A8830 : (selected ? 0xFF4A2848 : 0xFF3A3028);
+            int lvBorderL = lvSel ? 0xFF7AB848 : (selected ? 0xFF6A4868 : 0xFF5A5048);
+            int lvBorderD = lvSel ? 0xFF2A4810 : (selected ? 0xFF2A0828 : 0xFF1A1008);
+            int lvY = ry + (ROW_H - LV_BTN) / 2;
+            context.fill(lvX, lvY, lvX + LV_BTN, lvY + LV_BTN, lvBg);
+            context.fill(lvX, lvY, lvX + LV_BTN, lvY + 1, lvBorderL);
+            context.fill(lvX, lvY, lvX + 1, lvY + LV_BTN, lvBorderL);
+            context.fill(lvX + LV_BTN - 1, lvY + 1, lvX + LV_BTN, lvY + LV_BTN, lvBorderD);
+            context.fill(lvX + 1, lvY + LV_BTN - 1, lvX + LV_BTN, lvY + LV_BTN, lvBorderD);
+
             String r = toRoman(lv);
             int tw = textRenderer.getWidth(r);
-            int lvColor = lvSel ? 0xFF80FF40 : (selected ? 0xFFC0A0C0 : 0xFF8A7A6A);
-            context.drawTextWithShadow(textRenderer, r, lvX + (12 - tw) / 2, ty, lvColor);
-            lvX += 14;
+            int lvColor = lvSel ? 0xFFC0FF80 : (selected ? 0xFFB890B8 : 0xFF7A6A5A);
+            context.drawTextWithShadow(textRenderer, r, lvX + (LV_BTN - tw) / 2, lvY + 3, lvColor);
+            lvX += LV_BTN + LV_GAP;
         }
     }
 
@@ -251,8 +280,8 @@ public class CatalogueScreen extends HandledScreen<CatalogueScreenHandler> {
         if (mx < cx || mx >= cx + CAT_W || my < cy || my >= cy + CAT_H) return;
 
         List<CatalogueEntry> entries = handler.getEntries();
-        int idx = scrollOffset + (my - cy) / ROW_H;
-        if (idx >= entries.size()) return;
+        int idx = scrollOffset + (my - cy - 2) / (ROW_H + 1);
+        if (idx < 0 || idx >= entries.size()) return;
 
         CatalogueEntry entry = entries.get(idx);
         RegistryKey<Enchantment> key = entry.key();
@@ -263,7 +292,7 @@ public class CatalogueScreen extends HandledScreen<CatalogueScreenHandler> {
         int lapisCost = EnchantmentCosts.lapisCost(level);
         int reagentCost = EnchantmentCosts.reagentCost(level, handler.getNormalBookshelves());
         int xpCost = EnchantmentCosts.xpCost(key, level);
-        int slotCost = EnchantmentCosts.slotCost(key, level);
+        int slotCost = EnchantmentCosts.slotCost(entry.entry(), level);
 
         ItemStack item = handler.getSlot(0).getStack();
         ItemStack lapis = handler.getSlot(1).getStack();
@@ -283,7 +312,12 @@ public class CatalogueScreen extends HandledScreen<CatalogueScreenHandler> {
         tooltip.add(costLine("Lapis Lazuli", lapisCost, hasLapis));
         tooltip.add(costLine(reagentItem.getName().getString(), reagentCost, hasReagent));
         tooltip.add(costLine("XP Levels", xpCost, hasXp));
-        tooltip.add(costLine("Slots", slotCost, hasSlots));
+        if (slotCost > 0) {
+            tooltip.add(costLine("Slots", slotCost, hasSlots));
+        } else {
+            tooltip.add(Text.literal("Slots: ").formatted(Formatting.GRAY)
+                    .append(Text.literal("+1").formatted(Formatting.GREEN)));
+        }
 
         if (handler.getNormalBookshelves() > 0) {
             int pct = (int) (EnchantmentCosts.baseReagentCost(level) > 0
@@ -303,12 +337,17 @@ public class CatalogueScreen extends HandledScreen<CatalogueScreenHandler> {
     }
 
     private void drawScrollbar(DrawContext context, int sx, int sy, int sh) {
-        context.fill(sx, sy, sx + SCROLLBAR_W, sy + sh, 0x40000000);
-        if (!shouldScroll()) return;
+        context.fill(sx, sy, sx + SCROLLBAR_W, sy + sh, 0xFF2A2218);
+        if (!shouldScroll()) {
+            context.fill(sx, sy, sx + SCROLLBAR_W, sy + sh, SLOT_BG);
+            border3D(context, sx, sy, SCROLLBAR_W, sh, 0xFFC6C6C6, 0xFF555555);
+            return;
+        }
 
         int thumbH = Math.max(10, sh * VISIBLE_ROWS / handler.getEntries().size());
         int thumbY = sy + (int) ((sh - thumbH) * scrollAmount);
-        context.fill(sx, thumbY, sx + SCROLLBAR_W, thumbY + thumbH, PURPLE_LIGHT);
+        context.fill(sx, thumbY, sx + SCROLLBAR_W, thumbY + thumbH, SLOT_BG);
+        border3D(context, sx, thumbY, SCROLLBAR_W, thumbH, 0xFFC6C6C6, 0xFF555555);
     }
 
     private void drawSlotBar(DrawContext context, int x, int y) {
@@ -322,74 +361,44 @@ public class CatalogueScreen extends HandledScreen<CatalogueScreenHandler> {
         int pendingCost = 0;
         if (handler.getSelectedIndex() >= 0 && handler.getSelectedIndex() < handler.getEntries().size()) {
             CatalogueEntry e = handler.getEntries().get(handler.getSelectedIndex());
-            pendingCost = EnchantmentCosts.slotCost(e.key(), handler.getSelectedLevel());
+            pendingCost = EnchantmentCosts.slotCost(e.entry(), handler.getSelectedLevel());
         }
 
-        int barX = x + CAT_X;
         int barY = y + SLOT_BAR_Y;
-        int lw = 12, gap = 2;
-        int totalW = max * lw + (max - 1) * gap;
-        int sx = barX + (CAT_W - totalW) / 2;
+        int pw = 11, ph = 6, gap = 2;
+        String countText = used + "/" + max;
+        int countW = textRenderer.getWidth(countText);
+        int rightEdge = x + BG_W - 4;
+        int barX = rightEdge - countW - 4 - max * (pw + gap);
 
         for (int i = 0; i < max; i++) {
-            int lx = sx + i * (lw + gap);
+            int px = barX + i * (pw + gap);
+            int pipBg, pipBorderL, pipBorderD;
             if (i < used) {
-                context.fill(lx, barY, lx + lw, barY + 8, PURPLE_LIGHT);
+                pipBg = 0xFF7B48B8; pipBorderL = 0xFF9B68D8; pipBorderD = 0xFF3B1878;
             } else if (i < used + pendingCost) {
                 boolean blink = (System.currentTimeMillis() / 400) % 2 == 0;
-                context.fill(lx, barY, lx + lw, barY + 8, blink ? PURPLE_BRIGHT : 0xFF5030A0);
+                pipBg = blink ? 0xFFB880F0 : 0xFF5030A0;
+                pipBorderL = 0xFFD8A0FF; pipBorderD = 0xFF6840A0;
             } else {
-                context.fill(lx, barY, lx + lw, barY + 8, PURPLE_MID);
+                pipBg = 0xFF2A1848; pipBorderL = 0xFF3A2858; pipBorderD = 0xFF1A0838;
             }
+            context.fill(px, barY, px + pw, barY + ph, pipBg);
+            context.fill(px, barY, px + pw, barY + 1, pipBorderL);
+            context.fill(px, barY, px + 1, barY + ph, pipBorderL);
+            context.fill(px + pw - 1, barY + 1, px + pw, barY + ph, pipBorderD);
+            context.fill(px + 1, barY + ph - 1, px + pw, barY + ph, pipBorderD);
         }
 
-        context.drawTextWithShadow(textRenderer, used + "/" + max, sx + totalW + 6, barY, TEXT_LIGHT);
-    }
-
-    private void drawEnchantButton(DrawContext context, int x, int y, int mx, int my) {
-        int bx = x + BTN_X, by = y + BTN_Y;
-        boolean can = canEnchantNow();
-        boolean hover = mx >= bx && mx < bx + BTN_W && my >= by && my < by + BTN_H;
-
-        int bg = can ? (hover ? 0xFF50B050 : 0xFF408040) : 0xFF555555;
-        context.fill(bx, by, bx + BTN_W, by + BTN_H, bg);
-        border3D(context, bx, by, BTN_W, BTN_H,
-                can ? 0xFF70D070 : 0xFF777777,
-                can ? 0xFF206020 : 0xFF333333);
-
-        String label = "Enchant";
-        context.drawTextWithShadow(textRenderer, label,
-                bx + (BTN_W - textRenderer.getWidth(label)) / 2,
-                by + (BTN_H - 8) / 2,
-                can ? 0xFFFFFFFF : 0xFF999999);
+        int textX = barX + max * (pw + gap) + 2;
+        context.drawTextWithShadow(textRenderer, countText, textX, barY - 1, TEXT_LIGHT);
     }
 
     private void drawPlayerSlotBorders(DrawContext context, int x, int y) {
-        for (int i = 3; i < handler.slots.size(); i++) {
+        for (int i = 4; i < handler.slots.size(); i++) {
             Slot slot = handler.slots.get(i);
             slotBorder(context, x + slot.x - 1, y + slot.y - 1);
         }
-    }
-
-    private boolean canEnchantNow() {
-        if (handler.getSelectedIndex() < 0) return false;
-        List<CatalogueEntry> entries = handler.getEntries();
-        if (handler.getSelectedIndex() >= entries.size()) return false;
-
-        CatalogueEntry entry = entries.get(handler.getSelectedIndex());
-        int level = handler.getSelectedLevel();
-        RegistryKey<Enchantment> key = entry.key();
-        ItemStack item = handler.getSlot(0).getStack();
-        ItemStack lapis = handler.getSlot(1).getStack();
-        ItemStack reagent = handler.getSlot(2).getStack();
-
-        if (SlotSystem.getAvailableSlots(item) < EnchantmentCosts.slotCost(key, level)) return false;
-        if (MinecraftClient.getInstance().player.isCreative()) return true;
-
-        return lapis.getCount() >= EnchantmentCosts.lapisCost(level)
-                && reagent.isOf(EnchantmentCosts.reagent(key))
-                && reagent.getCount() >= EnchantmentCosts.reagentCost(level, handler.getNormalBookshelves())
-                && MinecraftClient.getInstance().player.experienceLevel >= EnchantmentCosts.xpCost(key, level);
     }
 
     // --- Input ---
@@ -399,37 +408,27 @@ public class CatalogueScreen extends HandledScreen<CatalogueScreenHandler> {
         double mx = click.x(), my = click.y();
         int x = this.x, y = this.y;
 
-        if (clickEnchant(mx, my, x, y)) return true;
         if (clickRow(mx, my, x, y)) return true;
         if (clickScroll(mx, my, x, y)) return true;
 
         return super.mouseClicked(click, doubled);
     }
 
-    private boolean clickEnchant(double mx, double my, int x, int y) {
-        int bx = x + BTN_X, by = y + BTN_Y;
-        if (mx < bx || mx >= bx + BTN_W || my < by || my >= by + BTN_H) return false;
-        if (!canEnchantNow()) return false;
-        MinecraftClient.getInstance().getSoundManager().play(PositionedSoundInstance.ui(SoundEvents.BLOCK_ENCHANTMENT_TABLE_USE, 1.0F));
-        client.interactionManager.clickButton(handler.syncId, CatalogueScreenHandler.ENCHANT_BUTTON_ID);
-        return true;
-    }
-
     private boolean clickRow(double mx, double my, int x, int y) {
         int cx = x + CAT_X, cy = y + CAT_Y;
         int rowW = CAT_W - SCROLLBAR_W - 4;
-        if (mx < cx + 1 || mx >= cx + 1 + rowW || my < cy || my >= cy + CAT_H) return false;
+        if (mx < cx + 2 || mx >= cx + 2 + rowW || my < cy + 2 || my >= cy + CAT_H - 2) return false;
 
         List<CatalogueEntry> entries = handler.getEntries();
-        int idx = scrollOffset + (int) (my - cy) / ROW_H;
-        if (idx >= entries.size()) return false;
+        int idx = scrollOffset + (int) (my - cy - 2) / (ROW_H + 1);
+        if (idx < 0 || idx >= entries.size()) return false;
 
         CatalogueEntry entry = entries.get(idx);
-        int rx = cx + 1;
-        int lvX = rx + rowW - 2 - entry.maxLevel() * 14;
+        int rx = cx + 2;
+        int lvX = rx + rowW - 2 - entry.maxLevel() * (LV_BTN + LV_GAP);
         int level = 1;
         if (mx >= lvX) {
-            int lvIdx = (int) (mx - lvX) / 14;
+            int lvIdx = (int) (mx - lvX) / (LV_BTN + LV_GAP);
             if (lvIdx >= 0 && lvIdx < entry.maxLevel()) level = lvIdx + 1;
         }
 
@@ -440,9 +439,10 @@ public class CatalogueScreen extends HandledScreen<CatalogueScreenHandler> {
     }
 
     private boolean clickScroll(double mx, double my, int x, int y) {
-        int sx = x + CAT_X + CAT_W - SCROLLBAR_W - 1;
-        int sy = y + CAT_Y;
-        if (mx >= sx && mx < sx + SCROLLBAR_W && my >= sy && my < sy + CAT_H && shouldScroll()) {
+        int sx = x + CAT_X + CAT_W - SCROLLBAR_W - 2;
+        int sy = y + CAT_Y + 2;
+        int sh = CAT_H - 4;
+        if (mx >= sx && mx < sx + SCROLLBAR_W && my >= sy && my < sy + sh && shouldScroll()) {
             scrolling = true;
             return true;
         }
@@ -452,8 +452,9 @@ public class CatalogueScreen extends HandledScreen<CatalogueScreenHandler> {
     @Override
     public boolean mouseDragged(Click click, double dx, double dy) {
         if (scrolling && shouldScroll()) {
-            float top = this.y + CAT_Y;
-            scrollAmount = MathHelper.clamp((float) (click.y() - top) / CAT_H, 0, 1);
+            float top = this.y + CAT_Y + 2;
+            float sh = CAT_H - 4;
+            scrollAmount = MathHelper.clamp((float) (click.y() - top) / sh, 0, 1);
             scrollOffset = (int) (scrollAmount * getMaxScroll());
             return true;
         }
@@ -498,6 +499,15 @@ public class CatalogueScreen extends HandledScreen<CatalogueScreenHandler> {
         ctx.fill(x + 17, y + 1, x + 18, y + 18, BORDER_L);
         ctx.fill(x + 1, y + 17, x + 18, y + 18, BORDER_L);
         ctx.fill(x + 1, y + 1, x + 17, y + 17, SLOT_BG);
+    }
+
+    private String trimToWidth(String text, int maxWidth) {
+        int w = 0;
+        for (int i = 0; i < text.length(); i++) {
+            w += textRenderer.getWidth(Text.literal(String.valueOf(text.charAt(i))).setStyle(SGA_STYLE));
+            if (w > maxWidth) return text.substring(0, i);
+        }
+        return text;
     }
 
     private static String randomSga(int length) {

--- a/src/main/java/com/akitain/enchantmentoverhaul/client/CatalogueScreen.java
+++ b/src/main/java/com/akitain/enchantmentoverhaul/client/CatalogueScreen.java
@@ -19,12 +19,16 @@ import net.minecraft.registry.RegistryKey;
 import net.minecraft.registry.tag.EnchantmentTags;
 import net.minecraft.screen.slot.Slot;
 import net.minecraft.sound.SoundEvents;
+import net.minecraft.text.Style;
+import net.minecraft.text.StyleSpriteSource;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
+import net.minecraft.util.Identifier;
 import net.minecraft.util.math.MathHelper;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Random;
 
 @Environment(EnvType.CLIENT)
 public class CatalogueScreen extends HandledScreen<CatalogueScreenHandler> {
@@ -58,9 +62,13 @@ public class CatalogueScreen extends HandledScreen<CatalogueScreenHandler> {
     private static final int RED = 0xFFFF5555;
     private static final int GOLD = 0xFFFFAA00;
     private static final int BG = 0xFFC6C6C6;
+    private static final Style SGA_STYLE = Style.EMPTY.withFont(new StyleSpriteSource.Font(Identifier.of("minecraft", "alt"))).withColor(0x3A1A5E);
     private static final int SLOT_BG = 0xFF8B8B8B;
     private static final int BORDER_L = 0xFFFFFFFF;
     private static final int BORDER_D = 0xFF555555;
+
+    private static final String SGA_CHARS = "abcdefghijklmnopqrstuvwxyz";
+    private String sgaLine = randomSga(40);
 
     private float scrollAmount;
     private int scrollOffset;
@@ -143,6 +151,7 @@ public class CatalogueScreen extends HandledScreen<CatalogueScreenHandler> {
         borderInset(context, cx, cy, CAT_W, CAT_H);
 
         context.drawTextWithShadow(textRenderer, "Catalogue", cx, cy - 12, TEXT_LIGHT);
+        context.drawText(textRenderer, Text.literal(sgaLine).setStyle(SGA_STYLE), cx + 3, cy + CAT_H - 10, 0x3A1A5E, false);
 
         List<CatalogueEntry> entries = handler.getEntries();
         if (entries.isEmpty()) {
@@ -445,6 +454,15 @@ public class CatalogueScreen extends HandledScreen<CatalogueScreenHandler> {
         ctx.fill(x + 17, y + 1, x + 18, y + 18, BORDER_L);
         ctx.fill(x + 1, y + 17, x + 18, y + 18, BORDER_L);
         ctx.fill(x + 1, y + 1, x + 17, y + 17, SLOT_BG);
+    }
+
+    private static String randomSga(int length) {
+        Random rng = new Random();
+        StringBuilder sb = new StringBuilder(length);
+        for (int i = 0; i < length; i++) {
+            sb.append(SGA_CHARS.charAt(rng.nextInt(SGA_CHARS.length())));
+        }
+        return sb.toString();
     }
 
     private static String toRoman(int n) {

--- a/src/main/java/com/akitain/enchantmentoverhaul/component/ModComponents.java
+++ b/src/main/java/com/akitain/enchantmentoverhaul/component/ModComponents.java
@@ -10,14 +10,22 @@ import net.minecraft.util.Identifier;
 
 public class ModComponents {
 
-    public static final ComponentType<Integer> GRINDSTONE_PENALTY = Registry.register(
-            Registries.DATA_COMPONENT_TYPE,
-            Identifier.of(EnchantmentOverhaul.MOD_ID, "grindstone_penalty"),
-            ComponentType.<Integer>builder()
-                    .codec(Codec.INT)
-                    .packetCodec(PacketCodecs.VAR_INT)
-                    .build()
-    );
+    public static final ComponentType<Integer> GRINDSTONE_PENALTY = intComponent("grindstone_penalty");
+    public static final ComponentType<Integer> HONING_LEVEL = intComponent("honing_level");
+    public static final ComponentType<Integer> WARDING_LEVEL = intComponent("warding_level");
+    public static final ComponentType<Integer> TEMPERING_LEVEL = intComponent("tempering_level");
+    public static final ComponentType<Integer> GRINDING_LEVEL = intComponent("grinding_level");
+
+    private static ComponentType<Integer> intComponent(String name) {
+        return Registry.register(
+                Registries.DATA_COMPONENT_TYPE,
+                Identifier.of(EnchantmentOverhaul.MOD_ID, name),
+                ComponentType.<Integer>builder()
+                        .codec(Codec.INT)
+                        .packetCodec(PacketCodecs.VAR_INT)
+                        .build()
+        );
+    }
 
     public static void register() {
     }

--- a/src/main/java/com/akitain/enchantmentoverhaul/enchant/CatalogueScreenHandler.java
+++ b/src/main/java/com/akitain/enchantmentoverhaul/enchant/CatalogueScreenHandler.java
@@ -159,12 +159,12 @@ public class CatalogueScreenHandler extends ScreenHandler {
 
     private boolean canAfford(PlayerEntity player, ItemStack item, ItemStack lapis, ItemStack reagent,
                                RegistryKey<Enchantment> key, int lapisNeeded, int reagentNeeded, int xpNeeded, int slotsNeeded) {
+        if (SlotSystem.getAvailableSlots(item) < slotsNeeded) return false;
         if (player.isCreative()) return true;
         if (lapis.getCount() < lapisNeeded) return false;
         if (reagent.getCount() < reagentNeeded) return false;
         if (!reagent.isOf(EnchantmentCosts.reagent(key))) return false;
-        if (player.experienceLevel < xpNeeded) return false;
-        return SlotSystem.getAvailableSlots(item) >= slotsNeeded;
+        return player.experienceLevel >= xpNeeded;
     }
 
     @Override

--- a/src/main/java/com/akitain/enchantmentoverhaul/enchant/CatalogueScreenHandler.java
+++ b/src/main/java/com/akitain/enchantmentoverhaul/enchant/CatalogueScreenHandler.java
@@ -26,15 +26,14 @@ import java.util.Set;
 
 public class CatalogueScreenHandler extends ScreenHandler {
 
-    public static final int ENCHANT_BUTTON_ID = 1000;
-
-    private final Inventory inventory = new SimpleInventory(3) {
+    private final Inventory inputInventory = new SimpleInventory(3) {
         @Override
         public void markDirty() {
             super.markDirty();
             CatalogueScreenHandler.this.onContentChanged(this);
         }
     };
+    private final Inventory outputInventory = new SimpleInventory(1);
 
     private final ScreenHandlerContext context;
     private final DynamicRegistryManager registryManager;
@@ -57,28 +56,51 @@ public class CatalogueScreenHandler extends ScreenHandler {
         this.unlockedIds = Set.copyOf(unlocked);
         this.normalBookshelves = normalBookshelves;
 
-        this.addSlot(new Slot(this.inventory, 0, 18, 22) {
+        this.addSlot(new Slot(this.inputInventory, 0, 9, 60) {
             @Override
             public int getMaxItemCount() { return 1; }
+            @Override
+            public boolean canInsert(ItemStack stack) { return !stack.isOf(Items.BOOK); }
         });
-        this.addSlot(new Slot(this.inventory, 1, 18, 48) {
+        this.addSlot(new Slot(this.inputInventory, 1, 31, 60) {
             @Override
             public boolean canInsert(ItemStack stack) { return stack.isOf(Items.LAPIS_LAZULI); }
         });
-        this.addSlot(new Slot(this.inventory, 2, 18, 74));
-        this.addPlayerSlots(playerInventory, 59, 148);
+        this.addSlot(new Slot(this.inputInventory, 2, 20, 80) {
+            @Override
+            public boolean canInsert(ItemStack stack) { return EnchantmentCosts.isReagent(stack.getItem()); }
+        });
+
+        this.addSlot(new Slot(this.outputInventory, 0, 20, 106) {
+            @Override
+            public boolean canInsert(ItemStack stack) { return false; }
+
+            @Override
+            public boolean canTakeItems(PlayerEntity player) {
+                return CatalogueScreenHandler.this.canTakeOutput(player);
+            }
+
+            @Override
+            public void onTakeItem(PlayerEntity player, ItemStack stack) {
+                CatalogueScreenHandler.this.onOutputTaken(player);
+                super.onTakeItem(player, stack);
+            }
+        });
+
+        this.addPlayerSlots(playerInventory, 7, 140);
     }
 
     @Override
     public void onContentChanged(Inventory inv) {
-        if (inv != this.inventory) return;
+        if (inv != this.inputInventory) return;
         this.selectedIndex = -1;
         this.selectedLevel = 1;
         rebuildEntries();
+        updateResult();
     }
 
     public void rebuildEntries() {
-        ItemStack item = this.inventory.getStack(0);
+        ItemStack item = this.inputInventory.getStack(0);
         if (item.isEmpty()) {
             this.entries = List.of();
             return;
@@ -96,7 +118,6 @@ public class CatalogueScreenHandler extends ScreenHandler {
             if (DisabledEnchantments.isDisabled(entry)) continue;
             if (!entry.value().isAcceptableItem(item)) continue;
             if (existing.getEnchantments().contains(entry)) continue;
-
             if (!unlockedIds.contains(key.getValue())) continue;
 
             int maxLevel = entry.value().getMaxLevel();
@@ -108,63 +129,77 @@ public class CatalogueScreenHandler extends ScreenHandler {
 
     @Override
     public boolean onButtonClick(PlayerEntity player, int id) {
-        if (id == ENCHANT_BUTTON_ID) return tryEnchant(player);
-
         if (id >= 0 && id < 1000) {
             int index = id / 10;
             int level = (id % 10) + 1;
             if (index < entries.size()) {
                 this.selectedIndex = index;
                 this.selectedLevel = Math.min(level, entries.get(index).maxLevel());
+                updateResult();
                 return true;
             }
         }
         return false;
     }
 
-    private boolean tryEnchant(PlayerEntity player) {
-        if (selectedIndex < 0 || selectedIndex >= entries.size()) return false;
-
-        CatalogueEntry entry = entries.get(selectedIndex);
-
-        RegistryKey<Enchantment> key = entry.key();
-        int level = Math.min(selectedLevel, entry.maxLevel());
-
-        int lapisNeeded = EnchantmentCosts.lapisCost(level);
-        int reagentNeeded = EnchantmentCosts.reagentCost(level, normalBookshelves);
-        int xpNeeded = EnchantmentCosts.xpCost(key, level);
-        int slotsNeeded = EnchantmentCosts.slotCost(key, level);
-
-        ItemStack item = this.inventory.getStack(0);
-        ItemStack lapis = this.inventory.getStack(1);
-        ItemStack reagent = this.inventory.getStack(2);
-
-        if (!canAfford(player, item, lapis, reagent, key, lapisNeeded, reagentNeeded, xpNeeded, slotsNeeded))
-            return false;
-
-        item.addEnchantment(entry.entry(), level);
-
-        if (!player.isCreative()) {
-            lapis.decrement(lapisNeeded);
-            reagent.decrement(reagentNeeded);
-            player.addExperienceLevels(-xpNeeded);
+    private void updateResult() {
+        if (selectedIndex < 0 || selectedIndex >= entries.size()) {
+            outputInventory.setStack(0, ItemStack.EMPTY);
+            return;
         }
 
-        this.selectedIndex = -1;
-        this.selectedLevel = 1;
-        rebuildEntries();
-        this.sendContentUpdates();
-        return true;
+        ItemStack item = inputInventory.getStack(0);
+        if (item.isEmpty()) {
+            outputInventory.setStack(0, ItemStack.EMPTY);
+            return;
+        }
+
+        CatalogueEntry entry = entries.get(selectedIndex);
+        int level = Math.min(selectedLevel, entry.maxLevel());
+
+        int slotsNeeded = EnchantmentCosts.slotCost(entry.entry(), level);
+        if (SlotSystem.getAvailableSlots(item) < slotsNeeded) {
+            outputInventory.setStack(0, ItemStack.EMPTY);
+            return;
+        }
+
+        ItemStack result = item.copy();
+        result.addEnchantment(entry.entry(), level);
+        outputInventory.setStack(0, result);
     }
 
-    private boolean canAfford(PlayerEntity player, ItemStack item, ItemStack lapis, ItemStack reagent,
-                               RegistryKey<Enchantment> key, int lapisNeeded, int reagentNeeded, int xpNeeded, int slotsNeeded) {
-        if (SlotSystem.getAvailableSlots(item) < slotsNeeded) return false;
+    private boolean canTakeOutput(PlayerEntity player) {
+        if (selectedIndex < 0 || selectedIndex >= entries.size()) return false;
+        CatalogueEntry entry = entries.get(selectedIndex);
+        int level = Math.min(selectedLevel, entry.maxLevel());
+
+        ItemStack item = inputInventory.getStack(0);
+        if (SlotSystem.getAvailableSlots(item) < EnchantmentCosts.slotCost(entry.entry(), level)) return false;
         if (player.isCreative()) return true;
-        if (lapis.getCount() < lapisNeeded) return false;
-        if (reagent.getCount() < reagentNeeded) return false;
-        if (!reagent.isOf(EnchantmentCosts.reagent(key))) return false;
-        return player.experienceLevel >= xpNeeded;
+
+        ItemStack lapis = inputInventory.getStack(1);
+        ItemStack reagent = inputInventory.getStack(2);
+        RegistryKey<Enchantment> key = entry.key();
+        return lapis.getCount() >= EnchantmentCosts.lapisCost(level)
+                && reagent.isOf(EnchantmentCosts.reagent(key))
+                && reagent.getCount() >= EnchantmentCosts.reagentCost(level, normalBookshelves)
+                && player.experienceLevel >= EnchantmentCosts.xpCost(key, level);
+    }
+
+    private void onOutputTaken(PlayerEntity player) {
+        if (selectedIndex < 0 || selectedIndex >= entries.size()) return;
+
+        CatalogueEntry entry = entries.get(selectedIndex);
+        int level = Math.min(selectedLevel, entry.maxLevel());
+        RegistryKey<Enchantment> key = entry.key();
+
+        if (!player.isCreative()) {
+            inputInventory.getStack(1).decrement(EnchantmentCosts.lapisCost(level));
+            inputInventory.getStack(2).decrement(EnchantmentCosts.reagentCost(level, normalBookshelves));
+            player.addExperienceLevels(-EnchantmentCosts.xpCost(key, level));
+        }
+
+        inputInventory.setStack(0, ItemStack.EMPTY);
     }
 
     @Override
@@ -175,12 +210,18 @@ public class CatalogueScreenHandler extends ScreenHandler {
         ItemStack stack = slot.getStack();
         ItemStack copy = stack.copy();
 
-        if (slotIndex < 3) {
-            if (!this.insertItem(stack, 3, 39, true)) return ItemStack.EMPTY;
+        if (slotIndex == 3) {
+            if (!canTakeOutput(player)) return ItemStack.EMPTY;
+            if (!this.insertItem(stack, 4, 40, true)) return ItemStack.EMPTY;
+            onOutputTaken(player);
+        } else if (slotIndex < 3) {
+            if (!this.insertItem(stack, 4, 40, true)) return ItemStack.EMPTY;
         } else if (stack.isOf(Items.LAPIS_LAZULI)) {
             if (!this.insertItem(stack, 1, 2, false)) return ItemStack.EMPTY;
         } else {
-            if (!this.insertItem(stack, 0, 1, false)) return ItemStack.EMPTY;
+            if (!this.insertItem(stack, 0, 1, false))
+                if (!this.insertItem(stack, 2, 3, false))
+                    return ItemStack.EMPTY;
         }
 
         if (stack.isEmpty()) slot.setStack(ItemStack.EMPTY);
@@ -192,7 +233,7 @@ public class CatalogueScreenHandler extends ScreenHandler {
     @Override
     public void onClosed(PlayerEntity player) {
         super.onClosed(player);
-        this.context.run((world, pos) -> this.dropInventory(player, this.inventory));
+        this.context.run((world, pos) -> this.dropInventory(player, this.inputInventory));
     }
 
     @Override
@@ -209,6 +250,7 @@ public class CatalogueScreenHandler extends ScreenHandler {
     public void setSelection(int index, int level) {
         this.selectedIndex = index;
         this.selectedLevel = level;
+        updateResult();
     }
 
     public record CatalogueEntry(RegistryEntry<Enchantment> entry, RegistryKey<Enchantment> key, int maxLevel) {}

--- a/src/main/java/com/akitain/enchantmentoverhaul/enchant/EnchantmentCosts.java
+++ b/src/main/java/com/akitain/enchantmentoverhaul/enchant/EnchantmentCosts.java
@@ -5,6 +5,8 @@ import net.minecraft.enchantment.Enchantments;
 import net.minecraft.item.Item;
 import net.minecraft.item.Items;
 import net.minecraft.registry.RegistryKey;
+import net.minecraft.registry.entry.RegistryEntry;
+import net.minecraft.registry.tag.EnchantmentTags;
 
 import java.util.Map;
 
@@ -70,8 +72,13 @@ public class EnchantmentCosts {
         return XP_BY_LEVEL[level];
     }
 
-    public static int slotCost(RegistryKey<Enchantment> key, int level) {
-        if (key.equals(Enchantments.MENDING)) return 3;
+    public static boolean isReagent(Item item) {
+        return item == Items.LAPIS_LAZULI || REAGENTS.containsValue(item);
+    }
+
+    public static int slotCost(RegistryEntry<Enchantment> entry, int level) {
+        if (entry.isIn(EnchantmentTags.CURSE)) return 0;
+        if (entry.matchesKey(Enchantments.MENDING)) return 3;
         return level;
     }
 }

--- a/src/main/java/com/akitain/enchantmentoverhaul/mixin/ItemStackDamageMixin.java
+++ b/src/main/java/com/akitain/enchantmentoverhaul/mixin/ItemStackDamageMixin.java
@@ -1,0 +1,28 @@
+package com.akitain.enchantmentoverhaul.mixin;
+
+import com.akitain.enchantmentoverhaul.component.ModComponents;
+import net.minecraft.item.ItemStack;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.world.ServerWorld;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(ItemStack.class)
+public class ItemStackDamageMixin {
+
+    @Inject(method = "calculateDamage", at = @At("RETURN"), cancellable = true)
+    private void applyTempering(int damage, ServerWorld world, ServerPlayerEntity player, CallbackInfoReturnable<Integer> cir) {
+        ItemStack self = (ItemStack) (Object) this;
+        int level = self.getOrDefault(ModComponents.TEMPERING_LEVEL, 0);
+        if (level <= 0) return;
+
+        int remaining = cir.getReturnValue();
+        int result = 0;
+        for (int i = 0; i < remaining; i++) {
+            if (world.getRandom().nextInt(level + 1) == 0) result++;
+        }
+        cir.setReturnValue(result);
+    }
+}

--- a/src/main/java/com/akitain/enchantmentoverhaul/mixin/SmithingScreenHandlerMixin.java
+++ b/src/main/java/com/akitain/enchantmentoverhaul/mixin/SmithingScreenHandlerMixin.java
@@ -1,0 +1,73 @@
+package com.akitain.enchantmentoverhaul.mixin;
+
+import com.akitain.enchantmentoverhaul.smithing.SmithingTemplates;
+import com.akitain.enchantmentoverhaul.smithing.UpgradeType;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.screen.ForgingScreenHandler;
+import net.minecraft.screen.ScreenHandlerContext;
+import net.minecraft.screen.ScreenHandlerType;
+import net.minecraft.screen.SmithingScreenHandler;
+import net.minecraft.screen.slot.ForgingSlotsManager;
+import net.minecraft.entity.player.PlayerInventory;
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(SmithingScreenHandler.class)
+public abstract class SmithingScreenHandlerMixin extends ForgingScreenHandler {
+
+    @Unique
+    private int pendingXpCost = 0;
+
+    private SmithingScreenHandlerMixin(@Nullable ScreenHandlerType<?> type, int syncId, PlayerInventory playerInventory, ScreenHandlerContext context, ForgingSlotsManager forgingSlotsManager) {
+        super(type, syncId, playerInventory, context, forgingSlotsManager);
+    }
+
+    @Inject(method = "updateResult", at = @At("TAIL"))
+    private void applyCustomUpgrade(CallbackInfo ci) {
+        pendingXpCost = 0;
+
+        ItemStack template = this.input.getStack(0);
+        ItemStack base = this.input.getStack(1);
+        ItemStack material = this.input.getStack(2);
+
+        if (template.isEmpty() || base.isEmpty() || material.isEmpty()) return;
+
+        UpgradeType type = SmithingTemplates.getType(template.getItem());
+        if (type == null) return;
+
+        int level = SmithingTemplates.getMaterialLevel(material.getItem());
+        if (level == 0) return;
+        if (!type.appliesTo(base)) {
+            this.output.setStack(0, ItemStack.EMPTY);
+            return;
+        }
+        if (type.currentLevel(base) >= level) {
+            this.output.setStack(0, ItemStack.EMPTY);
+            return;
+        }
+
+        int xpCost = SmithingTemplates.getXpCost(level);
+        if (!this.player.isCreative() && this.player.experienceLevel < xpCost) {
+            this.output.setStack(0, ItemStack.EMPTY);
+            return;
+        }
+
+        ItemStack result = base.copy();
+        type.applyTo(result, level);
+        this.output.setStack(0, result);
+        pendingXpCost = xpCost;
+    }
+
+    @Inject(method = "onTakeOutput", at = @At("HEAD"))
+    private void chargeXp(PlayerEntity player, ItemStack stack, CallbackInfo ci) {
+        if (pendingXpCost > 0 && !player.isCreative()) {
+            player.addExperienceLevels(-pendingXpCost);
+        }
+        pendingXpCost = 0;
+    }
+}

--- a/src/main/java/com/akitain/enchantmentoverhaul/smithing/SmithingTemplates.java
+++ b/src/main/java/com/akitain/enchantmentoverhaul/smithing/SmithingTemplates.java
@@ -1,0 +1,58 @@
+package com.akitain.enchantmentoverhaul.smithing;
+
+import com.akitain.enchantmentoverhaul.EnchantmentOverhaul;
+import net.minecraft.item.Item;
+import net.minecraft.item.Items;
+import net.minecraft.registry.Registries;
+import net.minecraft.registry.Registry;
+import net.minecraft.util.Identifier;
+
+import java.util.Map;
+
+public class SmithingTemplates {
+
+    public static final Item HONING_TEMPLATE = register("honing_template");
+    public static final Item WARDING_TEMPLATE = register("warding_template");
+    public static final Item TEMPERING_TEMPLATE = register("tempering_template");
+    public static final Item GRINDING_TEMPLATE = register("grinding_template");
+
+    private static final Map<Item, UpgradeType> TEMPLATE_TO_TYPE = Map.of(
+            HONING_TEMPLATE, UpgradeType.HONING,
+            WARDING_TEMPLATE, UpgradeType.WARDING,
+            TEMPERING_TEMPLATE, UpgradeType.TEMPERING,
+            GRINDING_TEMPLATE, UpgradeType.GRINDING
+    );
+
+    private static final Map<Item, Integer> MATERIAL_TO_LEVEL = Map.of(
+            Items.COPPER_INGOT, 1,
+            Items.IRON_INGOT, 2,
+            Items.GOLD_INGOT, 3,
+            Items.DIAMOND, 4,
+            Items.NETHERITE_INGOT, 5
+    );
+
+    private static final int[] XP_COSTS = {0, 1, 3, 5, 8, 12};
+
+    public static UpgradeType getType(Item template) {
+        return TEMPLATE_TO_TYPE.get(template);
+    }
+
+    public static int getMaterialLevel(Item material) {
+        return MATERIAL_TO_LEVEL.getOrDefault(material, 0);
+    }
+
+    public static int getXpCost(int level) {
+        if (level < 1 || level > 5) return 0;
+        return XP_COSTS[level];
+    }
+
+    public static boolean isTemplate(Item item) {
+        return TEMPLATE_TO_TYPE.containsKey(item);
+    }
+
+    private static Item register(String name) {
+        return Registry.register(Registries.ITEM, Identifier.of(EnchantmentOverhaul.MOD_ID, name), new Item(new Item.Settings()));
+    }
+
+    public static void register() {}
+}

--- a/src/main/java/com/akitain/enchantmentoverhaul/smithing/SmithingTemplates.java
+++ b/src/main/java/com/akitain/enchantmentoverhaul/smithing/SmithingTemplates.java
@@ -5,6 +5,8 @@ import net.minecraft.item.Item;
 import net.minecraft.item.Items;
 import net.minecraft.registry.Registries;
 import net.minecraft.registry.Registry;
+import net.minecraft.registry.RegistryKey;
+import net.minecraft.registry.RegistryKeys;
 import net.minecraft.util.Identifier;
 
 import java.util.Map;
@@ -51,7 +53,9 @@ public class SmithingTemplates {
     }
 
     private static Item register(String name) {
-        return Registry.register(Registries.ITEM, Identifier.of(EnchantmentOverhaul.MOD_ID, name), new Item(new Item.Settings()));
+        Identifier id = Identifier.of(EnchantmentOverhaul.MOD_ID, name);
+        RegistryKey<Item> key = RegistryKey.of(RegistryKeys.ITEM, id);
+        return Registry.register(Registries.ITEM, key, new Item(new Item.Settings().registryKey(key)));
     }
 
     public static void register() {}

--- a/src/main/java/com/akitain/enchantmentoverhaul/smithing/UpgradeType.java
+++ b/src/main/java/com/akitain/enchantmentoverhaul/smithing/UpgradeType.java
@@ -1,0 +1,74 @@
+package com.akitain.enchantmentoverhaul.smithing;
+
+import com.akitain.enchantmentoverhaul.EnchantmentOverhaul;
+import com.akitain.enchantmentoverhaul.component.ModComponents;
+import net.minecraft.component.ComponentType;
+import net.minecraft.component.DataComponentTypes;
+import net.minecraft.component.type.AttributeModifierSlot;
+import net.minecraft.component.type.AttributeModifiersComponent;
+import net.minecraft.entity.attribute.EntityAttributeModifier;
+import net.minecraft.entity.attribute.EntityAttributes;
+import net.minecraft.item.ItemStack;
+import net.minecraft.registry.entry.RegistryEntry;
+import net.minecraft.registry.tag.ItemTags;
+import net.minecraft.util.Identifier;
+import net.minecraft.entity.attribute.EntityAttribute;
+
+public enum UpgradeType {
+    HONING(ModComponents.HONING_LEVEL),
+    WARDING(ModComponents.WARDING_LEVEL),
+    TEMPERING(ModComponents.TEMPERING_LEVEL),
+    GRINDING(ModComponents.GRINDING_LEVEL);
+
+    private final ComponentType<Integer> component;
+
+    UpgradeType(ComponentType<Integer> component) {
+        this.component = component;
+    }
+
+    public ComponentType<Integer> component() {
+        return component;
+    }
+
+    public boolean appliesTo(ItemStack stack) {
+        return switch (this) {
+            case HONING -> stack.isIn(ItemTags.WEAPON_ENCHANTABLE)
+                    || stack.isIn(ItemTags.BOW_ENCHANTABLE)
+                    || stack.isIn(ItemTags.CROSSBOW_ENCHANTABLE);
+            case WARDING -> stack.isIn(ItemTags.ARMOR_ENCHANTABLE);
+            case TEMPERING -> stack.isIn(ItemTags.DURABILITY_ENCHANTABLE);
+            case GRINDING -> stack.isIn(ItemTags.MINING_ENCHANTABLE);
+        };
+    }
+
+    public int currentLevel(ItemStack stack) {
+        return stack.getOrDefault(component, 0);
+    }
+
+    public void applyTo(ItemStack stack, int level) {
+        stack.set(component, level);
+
+        switch (this) {
+            case HONING -> applyAttribute(stack, EntityAttributes.ATTACK_DAMAGE, level, AttributeModifierSlot.MAINHAND);
+            case WARDING -> applyAttribute(stack, EntityAttributes.ARMOR, level, AttributeModifierSlot.ARMOR);
+            case GRINDING -> applyAttribute(stack, EntityAttributes.MINING_EFFICIENCY, level * 5, AttributeModifierSlot.MAINHAND);
+            case TEMPERING -> {} // handled via mixin on item damage calculation
+        }
+    }
+
+    private void applyAttribute(ItemStack stack, RegistryEntry<EntityAttribute> attribute, double value, AttributeModifierSlot slot) {
+        Identifier id = Identifier.of(EnchantmentOverhaul.MOD_ID, name().toLowerCase());
+        EntityAttributeModifier modifier = new EntityAttributeModifier(id, value, EntityAttributeModifier.Operation.ADD_VALUE);
+
+        AttributeModifiersComponent existing = stack.getOrDefault(DataComponentTypes.ATTRIBUTE_MODIFIERS, AttributeModifiersComponent.DEFAULT);
+        AttributeModifiersComponent.Builder builder = AttributeModifiersComponent.builder();
+
+        for (AttributeModifiersComponent.Entry entry : existing.modifiers()) {
+            if (!entry.modifier().idMatches(id)) {
+                builder.add(entry.attribute(), entry.modifier(), entry.slot(), entry.display());
+            }
+        }
+        builder.add(attribute, modifier, slot);
+        stack.set(DataComponentTypes.ATTRIBUTE_MODIFIERS, builder.build());
+    }
+}

--- a/src/main/java/com/akitain/enchantmentoverhaul/smithing/UpgradeType.java
+++ b/src/main/java/com/akitain/enchantmentoverhaul/smithing/UpgradeType.java
@@ -1,18 +1,18 @@
 package com.akitain.enchantmentoverhaul.smithing;
 
-import com.akitain.enchantmentoverhaul.EnchantmentOverhaul;
 import com.akitain.enchantmentoverhaul.component.ModComponents;
 import net.minecraft.component.ComponentType;
 import net.minecraft.component.DataComponentTypes;
 import net.minecraft.component.type.AttributeModifierSlot;
 import net.minecraft.component.type.AttributeModifiersComponent;
+import net.minecraft.entity.attribute.EntityAttribute;
 import net.minecraft.entity.attribute.EntityAttributeModifier;
 import net.minecraft.entity.attribute.EntityAttributes;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.registry.entry.RegistryEntry;
 import net.minecraft.registry.tag.ItemTags;
 import net.minecraft.util.Identifier;
-import net.minecraft.entity.attribute.EntityAttribute;
 
 public enum UpgradeType {
     HONING(ModComponents.HONING_LEVEL),
@@ -49,26 +49,39 @@ public enum UpgradeType {
         stack.set(component, level);
 
         switch (this) {
-            case HONING -> applyAttribute(stack, EntityAttributes.ATTACK_DAMAGE, level, AttributeModifierSlot.MAINHAND);
-            case WARDING -> applyAttribute(stack, EntityAttributes.ARMOR, level, AttributeModifierSlot.ARMOR);
-            case GRINDING -> applyAttribute(stack, EntityAttributes.MINING_EFFICIENCY, level * 5, AttributeModifierSlot.MAINHAND);
-            case TEMPERING -> {} // handled via mixin on item damage calculation
+            case HONING -> boostBaseModifier(stack, EntityAttributes.ATTACK_DAMAGE, Item.BASE_ATTACK_DAMAGE_MODIFIER_ID, level, AttributeModifierSlot.MAINHAND);
+            case WARDING -> addModifier(stack, EntityAttributes.ARMOR, level, AttributeModifierSlot.ARMOR);
+            case GRINDING -> addModifier(stack, EntityAttributes.MINING_EFFICIENCY, level * 5, AttributeModifierSlot.MAINHAND);
+            case TEMPERING -> {}
         }
     }
 
-    private void applyAttribute(ItemStack stack, RegistryEntry<EntityAttribute> attribute, double value, AttributeModifierSlot slot) {
-        Identifier id = Identifier.of(EnchantmentOverhaul.MOD_ID, name().toLowerCase());
-        EntityAttributeModifier modifier = new EntityAttributeModifier(id, value, EntityAttributeModifier.Operation.ADD_VALUE);
-
+    private void boostBaseModifier(ItemStack stack, RegistryEntry<EntityAttribute> attribute, Identifier baseId, double bonus, AttributeModifierSlot slot) {
         AttributeModifiersComponent existing = stack.getOrDefault(DataComponentTypes.ATTRIBUTE_MODIFIERS, AttributeModifiersComponent.DEFAULT);
         AttributeModifiersComponent.Builder builder = AttributeModifiersComponent.builder();
 
+        boolean found = false;
         for (AttributeModifiersComponent.Entry entry : existing.modifiers()) {
-            if (!entry.modifier().idMatches(id)) {
+            if (entry.modifier().idMatches(baseId)) {
+                double newValue = entry.modifier().value() + bonus;
+                EntityAttributeModifier boosted = new EntityAttributeModifier(baseId, newValue, entry.modifier().operation());
+                builder.add(entry.attribute(), boosted, entry.slot(), entry.display());
+                found = true;
+            } else {
                 builder.add(entry.attribute(), entry.modifier(), entry.slot(), entry.display());
             }
         }
-        builder.add(attribute, modifier, slot);
+
+        if (!found) {
+            builder.add(attribute, new EntityAttributeModifier(baseId, bonus, EntityAttributeModifier.Operation.ADD_VALUE), slot);
+        }
+
         stack.set(DataComponentTypes.ATTRIBUTE_MODIFIERS, builder.build());
+    }
+
+    private void addModifier(ItemStack stack, RegistryEntry<EntityAttribute> attribute, double value, AttributeModifierSlot slot) {
+        AttributeModifiersComponent existing = stack.getOrDefault(DataComponentTypes.ATTRIBUTE_MODIFIERS, AttributeModifiersComponent.DEFAULT);
+        stack.set(DataComponentTypes.ATTRIBUTE_MODIFIERS, existing.with(attribute,
+                new EntityAttributeModifier(Identifier.ofVanilla(name().toLowerCase()), value, EntityAttributeModifier.Operation.ADD_VALUE), slot));
     }
 }

--- a/src/main/resources/assets/enchantment-overhaul/items/grinding_template.json
+++ b/src/main/resources/assets/enchantment-overhaul/items/grinding_template.json
@@ -1,0 +1,6 @@
+{
+  "model": {
+    "type": "minecraft:model",
+    "model": "enchantment-overhaul:item/grinding_template"
+  }
+}

--- a/src/main/resources/assets/enchantment-overhaul/items/honing_template.json
+++ b/src/main/resources/assets/enchantment-overhaul/items/honing_template.json
@@ -1,0 +1,6 @@
+{
+  "model": {
+    "type": "minecraft:model",
+    "model": "enchantment-overhaul:item/honing_template"
+  }
+}

--- a/src/main/resources/assets/enchantment-overhaul/items/tempering_template.json
+++ b/src/main/resources/assets/enchantment-overhaul/items/tempering_template.json
@@ -1,0 +1,6 @@
+{
+  "model": {
+    "type": "minecraft:model",
+    "model": "enchantment-overhaul:item/tempering_template"
+  }
+}

--- a/src/main/resources/assets/enchantment-overhaul/items/warding_template.json
+++ b/src/main/resources/assets/enchantment-overhaul/items/warding_template.json
@@ -1,0 +1,6 @@
+{
+  "model": {
+    "type": "minecraft:model",
+    "model": "enchantment-overhaul:item/warding_template"
+  }
+}

--- a/src/main/resources/assets/enchantment-overhaul/lang/en_us.json
+++ b/src/main/resources/assets/enchantment-overhaul/lang/en_us.json
@@ -1,0 +1,6 @@
+{
+  "item.enchantment-overhaul.honing_template": "Honing Smithing Template",
+  "item.enchantment-overhaul.warding_template": "Warding Smithing Template",
+  "item.enchantment-overhaul.tempering_template": "Tempering Smithing Template",
+  "item.enchantment-overhaul.grinding_template": "Grinding Smithing Template"
+}

--- a/src/main/resources/assets/enchantment-overhaul/models/item/grinding_template.json
+++ b/src/main/resources/assets/enchantment-overhaul/models/item/grinding_template.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:item/generated",
+  "textures": {
+    "layer0": "enchantment-overhaul:item/grinding_template"
+  }
+}

--- a/src/main/resources/assets/enchantment-overhaul/models/item/honing_template.json
+++ b/src/main/resources/assets/enchantment-overhaul/models/item/honing_template.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:item/generated",
+  "textures": {
+    "layer0": "enchantment-overhaul:item/honing_template"
+  }
+}

--- a/src/main/resources/assets/enchantment-overhaul/models/item/tempering_template.json
+++ b/src/main/resources/assets/enchantment-overhaul/models/item/tempering_template.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:item/generated",
+  "textures": {
+    "layer0": "enchantment-overhaul:item/tempering_template"
+  }
+}

--- a/src/main/resources/assets/enchantment-overhaul/models/item/warding_template.json
+++ b/src/main/resources/assets/enchantment-overhaul/models/item/warding_template.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:item/generated",
+  "textures": {
+    "layer0": "enchantment-overhaul:item/warding_template"
+  }
+}

--- a/src/main/resources/data/enchantment-overhaul/recipe/smithing_upgrade.json
+++ b/src/main/resources/data/enchantment-overhaul/recipe/smithing_upgrade.json
@@ -1,0 +1,9 @@
+{
+  "type": "minecraft:smithing_transform",
+  "template": "#enchantment-overhaul:smithing_templates",
+  "base": "#minecraft:enchantable/durability",
+  "addition": "#enchantment-overhaul:smithing_materials",
+  "result": {
+    "id": "minecraft:iron_sword"
+  }
+}

--- a/src/main/resources/data/enchantment-overhaul/tags/item/smithing_materials.json
+++ b/src/main/resources/data/enchantment-overhaul/tags/item/smithing_materials.json
@@ -1,0 +1,9 @@
+{
+  "values": [
+    "minecraft:copper_ingot",
+    "minecraft:iron_ingot",
+    "minecraft:gold_ingot",
+    "minecraft:diamond",
+    "minecraft:netherite_ingot"
+  ]
+}

--- a/src/main/resources/data/enchantment-overhaul/tags/item/smithing_templates.json
+++ b/src/main/resources/data/enchantment-overhaul/tags/item/smithing_templates.json
@@ -1,0 +1,8 @@
+{
+  "values": [
+    "enchantment-overhaul:honing_template",
+    "enchantment-overhaul:warding_template",
+    "enchantment-overhaul:tempering_template",
+    "enchantment-overhaul:grinding_template"
+  ]
+}

--- a/src/main/resources/enchantment-overhaul.mixins.json
+++ b/src/main/resources/enchantment-overhaul.mixins.json
@@ -12,7 +12,9 @@
         "EnchantmentNameMixin",
         "ItemGroupsMixin",
         "EnchantingTableBlockMixin",
-        "GrindstoneScreenHandlerMixin"
+        "GrindstoneScreenHandlerMixin",
+        "SmithingScreenHandlerMixin",
+        "ItemStackDamageMixin"
     ],
     "client": [],
     "injectors": {


### PR DESCRIPTION
Adds the four smithing templates (Honing, Warding, Tempering, Grinding) with XP costs per material tier. Reworks the enchanting table UI to feel vanilla: output slot pattern, 176px width, SGA-only catalogue rows, reagent slot validation, curse/slot fixes, and visible title.