### PR TITLE
fix: smithing re-upgrades and anvil slot restoration

### DIFF
--- a/src/main/java/com/akitain/enchantmentoverhaul/EnchantmentOverhaulClient.java
+++ b/src/main/java/com/akitain/enchantmentoverhaul/EnchantmentOverhaulClient.java
@@ -39,6 +39,7 @@ public class EnchantmentOverhaulClient implements ClientModInitializer {
     }
 
     private static void addInnatePropertyLine(ItemStack stack, java.util.List<Text> lines) {
+        if (!stack.isIn(net.minecraft.registry.tag.ItemTags.ARMOR_ENCHANTABLE)) return;
         String material = InnateMaterialProperties.getMaterial(stack);
         if (material == null) return;
         String name = InnateMaterialProperties.getResistanceName(material);

--- a/src/main/java/com/akitain/enchantmentoverhaul/mixin/AnvilScreenHandlerMixin.java
+++ b/src/main/java/com/akitain/enchantmentoverhaul/mixin/AnvilScreenHandlerMixin.java
@@ -1,8 +1,13 @@
 package com.akitain.enchantmentoverhaul.mixin;
 
+import com.akitain.enchantmentoverhaul.component.ModComponents;
+import com.akitain.enchantmentoverhaul.enchant.SlotSystem;
 import net.minecraft.component.DataComponentTypes;
 import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+import net.minecraft.registry.Registries;
 import net.minecraft.screen.AnvilScreenHandler;
 import net.minecraft.screen.ForgingScreenHandler;
 import net.minecraft.screen.Property;
@@ -39,7 +44,8 @@ public abstract class AnvilScreenHandlerMixin extends ForgingScreenHandler {
         }
 
         ItemStack result = first.copy();
-        boolean changed = tryRepair(first, second, result) | tryRename(first, result);
+        int restoreCost = tryRestoreSlot(first, second, result);
+        boolean changed = (restoreCost > 0) | tryRepair(first, second, result) | tryRename(first, result);
 
         if (!second.isEmpty() && !changed) {
             clearOutput(ci);
@@ -52,9 +58,43 @@ public abstract class AnvilScreenHandlerMixin extends ForgingScreenHandler {
         }
 
         result.remove(DataComponentTypes.REPAIR_COST);
-        this.levelCost.set(1);
+        this.levelCost.set(Math.max(1, restoreCost));
         this.output.setStack(0, result);
         ci.cancel();
+    }
+
+    private int tryRestoreSlot(ItemStack first, ItemStack second, ItemStack result) {
+        int penalty = SlotSystem.getGrindstonePenalty(first);
+        if (penalty <= 0 || second.isEmpty()) return 0;
+
+        Item repairIngot = getRepairIngot(first);
+        if (repairIngot == null || !second.isOf(repairIngot)) return 0;
+
+        result.set(ModComponents.GRINDSTONE_PENALTY, penalty - 1);
+        return getRestoreCost(first);
+    }
+
+    private static Item getRepairIngot(ItemStack stack) {
+        String id = Registries.ITEM.getId(stack.getItem()).getPath();
+        if (id.startsWith("netherite_")) return Items.NETHERITE_INGOT;
+        if (id.startsWith("diamond_")) return Items.DIAMOND;
+        if (id.startsWith("golden_")) return Items.GOLD_INGOT;
+        if (id.startsWith("iron_") || id.startsWith("chainmail_")) return Items.IRON_INGOT;
+        if (id.startsWith("copper_")) return Items.COPPER_INGOT;
+        if (id.startsWith("leather_")) return Items.LEATHER;
+        if (id.startsWith("wooden_")) return Items.OAK_PLANKS;
+        if (id.startsWith("stone_")) return Items.COBBLESTONE;
+        return Items.IRON_INGOT;
+    }
+
+    private static int getRestoreCost(ItemStack stack) {
+        String id = Registries.ITEM.getId(stack.getItem()).getPath();
+        if (id.startsWith("netherite_")) return 10;
+        if (id.startsWith("diamond_")) return 8;
+        if (id.startsWith("golden_")) return 5;
+        if (id.startsWith("iron_") || id.startsWith("chainmail_")) return 5;
+        if (id.startsWith("copper_")) return 3;
+        return 2;
     }
 
     private boolean tryRepair(ItemStack first, ItemStack second, ItemStack result) {

--- a/src/main/java/com/akitain/enchantmentoverhaul/smithing/UpgradeType.java
+++ b/src/main/java/com/akitain/enchantmentoverhaul/smithing/UpgradeType.java
@@ -46,12 +46,13 @@ public enum UpgradeType {
     }
 
     public void applyTo(ItemStack stack, int level) {
+        int oldLevel = currentLevel(stack);
         stack.set(component, level);
 
         switch (this) {
-            case HONING -> boostBaseModifier(stack, EntityAttributes.ATTACK_DAMAGE, Item.BASE_ATTACK_DAMAGE_MODIFIER_ID, level, AttributeModifierSlot.MAINHAND);
-            case WARDING -> addModifier(stack, EntityAttributes.ARMOR, level, AttributeModifierSlot.ARMOR);
-            case GRINDING -> addModifier(stack, EntityAttributes.MINING_EFFICIENCY, level * 5, AttributeModifierSlot.MAINHAND);
+            case HONING -> boostBaseModifier(stack, EntityAttributes.ATTACK_DAMAGE, Item.BASE_ATTACK_DAMAGE_MODIFIER_ID, level - oldLevel, AttributeModifierSlot.MAINHAND);
+            case WARDING -> replaceModifier(stack, EntityAttributes.ARMOR, level, AttributeModifierSlot.ARMOR);
+            case GRINDING -> replaceModifier(stack, EntityAttributes.MINING_EFFICIENCY, level * 5, AttributeModifierSlot.MAINHAND);
             case TEMPERING -> {}
         }
     }
@@ -79,9 +80,16 @@ public enum UpgradeType {
         stack.set(DataComponentTypes.ATTRIBUTE_MODIFIERS, builder.build());
     }
 
-    private void addModifier(ItemStack stack, RegistryEntry<EntityAttribute> attribute, double value, AttributeModifierSlot slot) {
+    private void replaceModifier(ItemStack stack, RegistryEntry<EntityAttribute> attribute, double value, AttributeModifierSlot slot) {
+        Identifier modId = Identifier.ofVanilla(name().toLowerCase());
         AttributeModifiersComponent existing = stack.getOrDefault(DataComponentTypes.ATTRIBUTE_MODIFIERS, AttributeModifiersComponent.DEFAULT);
-        stack.set(DataComponentTypes.ATTRIBUTE_MODIFIERS, existing.with(attribute,
-                new EntityAttributeModifier(Identifier.ofVanilla(name().toLowerCase()), value, EntityAttributeModifier.Operation.ADD_VALUE), slot));
+        AttributeModifiersComponent.Builder builder = AttributeModifiersComponent.builder();
+        for (AttributeModifiersComponent.Entry entry : existing.modifiers()) {
+            if (!entry.modifier().idMatches(modId)) {
+                builder.add(entry.attribute(), entry.modifier(), entry.slot(), entry.display());
+            }
+        }
+        builder.add(attribute, new EntityAttributeModifier(modId, value, EntityAttributeModifier.Operation.ADD_VALUE), slot);
+        stack.set(DataComponentTypes.ATTRIBUTE_MODIFIERS, builder.build());
     }
 }


### PR DESCRIPTION
Fixes attribute stacking when re-upgrading smithing templates (Honing delta, Warding/Grinding replace). Adds anvil slot restoration: penalized item + material ingot restores 1 grindstone penalty for XP scaling by tier. Innate resistance tooltip now only shows on armor.