### PR TITLE
feat: add 9 new enchantments

### DIFF
--- a/src/main/java/com/akitain/enchantmentoverhaul/EnchantmentOverhaul.java
+++ b/src/main/java/com/akitain/enchantmentoverhaul/EnchantmentOverhaul.java
@@ -1,9 +1,11 @@
 package com.akitain.enchantmentoverhaul;
 
 import com.akitain.enchantmentoverhaul.component.ModComponents;
+import com.akitain.enchantmentoverhaul.enchant.MagneticHandler;
 import com.akitain.enchantmentoverhaul.enchant.ModScreenHandlers;
 import com.akitain.enchantmentoverhaul.smithing.SmithingTemplates;
 import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
 import net.fabricmc.fabric.api.itemgroup.v1.ItemGroupEvents;
 import net.minecraft.item.ItemGroups;
 import net.minecraft.item.ItemStack;
@@ -27,6 +29,8 @@ public class EnchantmentOverhaul implements ModInitializer {
             entries.add(new ItemStack(SmithingTemplates.TEMPERING_TEMPLATE));
             entries.add(new ItemStack(SmithingTemplates.GRINDING_TEMPLATE));
         });
+
+        ServerTickEvents.END_WORLD_TICK.register(MagneticHandler::tick);
 
         LOGGER.info("Enchantment Overhaul loaded");
     }

--- a/src/main/java/com/akitain/enchantmentoverhaul/enchant/EnchantmentCosts.java
+++ b/src/main/java/com/akitain/enchantmentoverhaul/enchant/EnchantmentCosts.java
@@ -44,7 +44,16 @@ public class EnchantmentCosts {
             entry(Enchantments.LURE, Items.TROPICAL_FISH),
             entry(Enchantments.MENDING, Items.AMETHYST_SHARD),
             entry(Enchantments.BINDING_CURSE, Items.IRON_CHAIN),
-            entry(Enchantments.VANISHING_CURSE, Items.PHANTOM_MEMBRANE)
+            entry(Enchantments.VANISHING_CURSE, Items.PHANTOM_MEMBRANE),
+            entry(ModEnchantments.STEP_UP, Items.RABBIT_FOOT),
+            entry(ModEnchantments.VENOM, Items.SPIDER_EYE),
+            entry(ModEnchantments.LAST_STAND, Items.GOLDEN_APPLE),
+            entry(ModEnchantments.CURSE_OF_FRAGILITY, Items.GLASS_PANE),
+            entry(ModEnchantments.CURSE_OF_HUNGER, Items.ROTTEN_FLESH),
+            entry(ModEnchantments.VEIL, Items.FERMENTED_SPIDER_EYE),
+            entry(ModEnchantments.BUOYANCY, Items.LILY_PAD),
+            entry(ModEnchantments.MAGNETIC, Items.COMPASS),
+            entry(ModEnchantments.HOMING, Items.ENDER_EYE)
     );
 
     private static final int[] XP_BY_LEVEL = {0, 2, 4, 7, 10};

--- a/src/main/java/com/akitain/enchantmentoverhaul/enchant/MagneticHandler.java
+++ b/src/main/java/com/akitain/enchantmentoverhaul/enchant/MagneticHandler.java
@@ -1,0 +1,43 @@
+package com.akitain.enchantmentoverhaul.enchant;
+
+import net.minecraft.component.DataComponentTypes;
+import net.minecraft.component.type.ItemEnchantmentsComponent;
+import net.minecraft.entity.ItemEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.Box;
+import net.minecraft.util.math.Vec3d;
+
+public class MagneticHandler {
+
+    private static final double[] RANGE_BY_LEVEL = {0, 3, 5, 8};
+
+    public static void tick(ServerWorld world) {
+        for (ServerPlayerEntity player : world.getPlayers()) {
+            ItemStack mainhand = player.getMainHandStack();
+            int level = getLevel(mainhand);
+            if (level <= 0) continue;
+
+            double range = level < RANGE_BY_LEVEL.length ? RANGE_BY_LEVEL[level] : RANGE_BY_LEVEL[RANGE_BY_LEVEL.length - 1];
+            Box box = player.getBoundingBox().expand(range);
+
+            for (ItemEntity item : world.getEntitiesByClass(ItemEntity.class, box, e -> !e.cannotPickup())) {
+                Vec3d dir = player.getEntityPos().add(0, 0.5, 0).subtract(item.getEntityPos());
+                double dist = dir.length();
+                if (dist < 1.0) continue;
+                Vec3d velocity = dir.normalize().multiply(0.3);
+                item.setVelocity(velocity);
+                item.velocityDirty = true;
+            }
+        }
+    }
+
+    private static int getLevel(ItemStack stack) {
+        ItemEnchantmentsComponent enchantments = stack.getOrDefault(DataComponentTypes.ENCHANTMENTS, ItemEnchantmentsComponent.DEFAULT);
+        for (var entry : enchantments.getEnchantmentEntries()) {
+            if (entry.getKey().matchesKey(ModEnchantments.MAGNETIC)) return entry.getIntValue();
+        }
+        return 0;
+    }
+}

--- a/src/main/java/com/akitain/enchantmentoverhaul/enchant/ModEnchantments.java
+++ b/src/main/java/com/akitain/enchantmentoverhaul/enchant/ModEnchantments.java
@@ -1,0 +1,24 @@
+package com.akitain.enchantmentoverhaul.enchant;
+
+import com.akitain.enchantmentoverhaul.EnchantmentOverhaul;
+import net.minecraft.enchantment.Enchantment;
+import net.minecraft.registry.RegistryKey;
+import net.minecraft.registry.RegistryKeys;
+import net.minecraft.util.Identifier;
+
+public class ModEnchantments {
+
+    public static final RegistryKey<Enchantment> STEP_UP = of("step_up");
+    public static final RegistryKey<Enchantment> VENOM = of("venom");
+    public static final RegistryKey<Enchantment> LAST_STAND = of("last_stand");
+    public static final RegistryKey<Enchantment> CURSE_OF_FRAGILITY = of("curse_of_fragility");
+    public static final RegistryKey<Enchantment> CURSE_OF_HUNGER = of("curse_of_hunger");
+    public static final RegistryKey<Enchantment> VEIL = of("veil");
+    public static final RegistryKey<Enchantment> BUOYANCY = of("buoyancy");
+    public static final RegistryKey<Enchantment> MAGNETIC = of("magnetic");
+    public static final RegistryKey<Enchantment> HOMING = of("homing");
+
+    private static RegistryKey<Enchantment> of(String name) {
+        return RegistryKey.of(RegistryKeys.ENCHANTMENT, Identifier.of(EnchantmentOverhaul.MOD_ID, name));
+    }
+}

--- a/src/main/java/com/akitain/enchantmentoverhaul/mixin/BuoyancyMixin.java
+++ b/src/main/java/com/akitain/enchantmentoverhaul/mixin/BuoyancyMixin.java
@@ -1,0 +1,34 @@
+package com.akitain.enchantmentoverhaul.mixin;
+
+import com.akitain.enchantmentoverhaul.enchant.ModEnchantments;
+import net.minecraft.component.DataComponentTypes;
+import net.minecraft.component.type.ItemEnchantmentsComponent;
+import net.minecraft.entity.EquipmentSlot;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.item.ItemStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(LivingEntity.class)
+public class BuoyancyMixin {
+
+    @Inject(method = "tickMovement", at = @At("HEAD"))
+    private void applyBuoyancy(CallbackInfo ci) {
+        LivingEntity self = (LivingEntity) (Object) this;
+        if (!self.isTouchingWater() || self.isSneaking()) return;
+
+        ItemStack boots = self.getEquippedStack(EquipmentSlot.FEET);
+        ItemEnchantmentsComponent enchantments = boots.getOrDefault(DataComponentTypes.ENCHANTMENTS, ItemEnchantmentsComponent.DEFAULT);
+        boolean hasBuoyancy = false;
+        for (var entry : enchantments.getEnchantmentEntries()) {
+            if (entry.getKey().matchesKey(ModEnchantments.BUOYANCY)) { hasBuoyancy = true; break; }
+        }
+        if (!hasBuoyancy) return;
+
+        if (self.isSubmergedInWater()) {
+            self.setVelocity(self.getVelocity().add(0, 0.05, 0));
+        }
+    }
+}

--- a/src/main/java/com/akitain/enchantmentoverhaul/mixin/HomingProjectileMixin.java
+++ b/src/main/java/com/akitain/enchantmentoverhaul/mixin/HomingProjectileMixin.java
@@ -1,0 +1,67 @@
+package com.akitain.enchantmentoverhaul.mixin;
+
+import com.akitain.enchantmentoverhaul.enchant.ModEnchantments;
+import net.minecraft.component.DataComponentTypes;
+import net.minecraft.component.type.ItemEnchantmentsComponent;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.projectile.PersistentProjectileEntity;
+import net.minecraft.entity.projectile.ProjectileEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.math.Box;
+import net.minecraft.util.math.Vec3d;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.List;
+
+@Mixin(PersistentProjectileEntity.class)
+public abstract class HomingProjectileMixin extends ProjectileEntity {
+
+    private HomingProjectileMixin() { super(null, null); }
+
+    @Shadow public abstract ItemStack getWeaponStack();
+    @Shadow protected abstract boolean isInGround();
+
+    @Inject(method = "tick", at = @At("HEAD"))
+    private void applyHoming(CallbackInfo ci) {
+        PersistentProjectileEntity self = (PersistentProjectileEntity) (Object) this;
+        if (isInGround() || self.getEntityWorld().isClient()) return;
+
+        ItemStack weapon = getWeaponStack();
+        if (weapon == null || weapon.isEmpty()) return;
+
+        ItemEnchantmentsComponent enchantments = weapon.getOrDefault(DataComponentTypes.ENCHANTMENTS, ItemEnchantmentsComponent.DEFAULT);
+        boolean hasHoming = false;
+        for (var entry : enchantments.getEnchantmentEntries()) {
+            if (entry.getKey().matchesKey(ModEnchantments.HOMING)) { hasHoming = true; break; }
+        }
+        if (!hasHoming) return;
+
+        Entity owner = this.getOwner();
+        Box searchBox = self.getBoundingBox().expand(8.0);
+        List<LivingEntity> targets = self.getEntityWorld().getEntitiesByClass(LivingEntity.class, searchBox,
+                e -> e != owner && e.isAlive() && !e.isSpectator());
+        if (targets.isEmpty()) return;
+
+        LivingEntity nearest = null;
+        double nearestDist = Double.MAX_VALUE;
+        for (LivingEntity target : targets) {
+            double dist = self.squaredDistanceTo(target);
+            if (dist < nearestDist) {
+                nearestDist = dist;
+                nearest = target;
+            }
+        }
+
+        Vec3d toTarget = nearest.getEyePos().subtract(self.getEntityPos()).normalize();
+        Vec3d velocity = self.getVelocity();
+        double speed = velocity.length();
+        Vec3d blended = velocity.normalize().multiply(0.85).add(toTarget.multiply(0.15)).normalize().multiply(speed);
+        self.setVelocity(blended);
+        self.velocityDirty = true;
+    }
+}

--- a/src/main/java/com/akitain/enchantmentoverhaul/mixin/ItemStackDamageMixin.java
+++ b/src/main/java/com/akitain/enchantmentoverhaul/mixin/ItemStackDamageMixin.java
@@ -1,7 +1,12 @@
 package com.akitain.enchantmentoverhaul.mixin;
 
 import com.akitain.enchantmentoverhaul.component.ModComponents;
+import com.akitain.enchantmentoverhaul.enchant.ModEnchantments;
+import net.minecraft.component.DataComponentTypes;
+import net.minecraft.component.type.ItemEnchantmentsComponent;
+import net.minecraft.enchantment.Enchantment;
 import net.minecraft.item.ItemStack;
+import net.minecraft.registry.RegistryKey;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.ServerWorld;
 import org.spongepowered.asm.mixin.Mixin;
@@ -13,16 +18,31 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 public class ItemStackDamageMixin {
 
     @Inject(method = "calculateDamage", at = @At("RETURN"), cancellable = true)
-    private void applyTempering(int damage, ServerWorld world, ServerPlayerEntity player, CallbackInfoReturnable<Integer> cir) {
+    private void applyDurabilityModifiers(int damage, ServerWorld world, ServerPlayerEntity player, CallbackInfoReturnable<Integer> cir) {
         ItemStack self = (ItemStack) (Object) this;
-        int level = self.getOrDefault(ModComponents.TEMPERING_LEVEL, 0);
-        if (level <= 0) return;
+        int result = cir.getReturnValue();
 
-        int remaining = cir.getReturnValue();
-        int result = 0;
-        for (int i = 0; i < remaining; i++) {
-            if (world.getRandom().nextInt(level + 1) == 0) result++;
+        int temperingLevel = self.getOrDefault(ModComponents.TEMPERING_LEVEL, 0);
+        if (temperingLevel > 0) {
+            int reduced = 0;
+            for (int i = 0; i < result; i++) {
+                if (world.getRandom().nextInt(temperingLevel + 1) == 0) reduced++;
+            }
+            result = reduced;
         }
+
+        if (hasEnchantment(self, ModEnchantments.CURSE_OF_FRAGILITY)) {
+            result *= 2;
+        }
+
         cir.setReturnValue(result);
+    }
+
+    private static boolean hasEnchantment(ItemStack stack, RegistryKey<Enchantment> key) {
+        ItemEnchantmentsComponent enchantments = stack.getOrDefault(DataComponentTypes.ENCHANTMENTS, ItemEnchantmentsComponent.DEFAULT);
+        for (var entry : enchantments.getEnchantmentEntries()) {
+            if (entry.getKey().matchesKey(key)) return true;
+        }
+        return false;
     }
 }

--- a/src/main/java/com/akitain/enchantmentoverhaul/mixin/LivingEntityDamageMixin.java
+++ b/src/main/java/com/akitain/enchantmentoverhaul/mixin/LivingEntityDamageMixin.java
@@ -1,8 +1,15 @@
 package com.akitain.enchantmentoverhaul.mixin;
 
 import com.akitain.enchantmentoverhaul.enchant.InnateMaterialProperties;
+import com.akitain.enchantmentoverhaul.enchant.ModEnchantments;
+import net.minecraft.component.DataComponentTypes;
+import net.minecraft.component.type.ItemEnchantmentsComponent;
+import net.minecraft.enchantment.Enchantment;
+import net.minecraft.entity.EquipmentSlot;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.damage.DamageSource;
+import net.minecraft.item.ItemStack;
+import net.minecraft.registry.entry.RegistryEntry;
 import net.minecraft.server.world.ServerWorld;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -12,8 +19,28 @@ import org.spongepowered.asm.mixin.injection.ModifyVariable;
 public class LivingEntityDamageMixin {
 
     @ModifyVariable(method = "applyDamage", at = @At("HEAD"), argsOnly = true, ordinal = 0)
-    private float applyInnateMaterialResistance(float amount, ServerWorld world, DamageSource source, float original) {
+    private float applyCustomResistances(float amount, ServerWorld world, DamageSource source, float original) {
         LivingEntity self = (LivingEntity) (Object) this;
-        return amount * InnateMaterialProperties.getDamageMultiplier(self, source);
+        float result = amount * InnateMaterialProperties.getDamageMultiplier(self, source);
+        result *= getLastStandMultiplier(self);
+        return result;
+    }
+
+    private static float getLastStandMultiplier(LivingEntity entity) {
+        if (entity.getHealth() > entity.getMaxHealth() * 0.2f) return 1.0f;
+
+        ItemStack chest = entity.getEquippedStack(EquipmentSlot.CHEST);
+        int level = getEnchantmentLevel(chest, ModEnchantments.LAST_STAND);
+        if (level <= 0) return 1.0f;
+
+        return 1.0f - (level * 0.1f);
+    }
+
+    private static int getEnchantmentLevel(ItemStack stack, net.minecraft.registry.RegistryKey<Enchantment> key) {
+        ItemEnchantmentsComponent enchantments = stack.getOrDefault(DataComponentTypes.ENCHANTMENTS, ItemEnchantmentsComponent.DEFAULT);
+        for (var entry : enchantments.getEnchantmentEntries()) {
+            if (entry.getKey().matchesKey(key)) return entry.getIntValue();
+        }
+        return 0;
     }
 }

--- a/src/main/java/com/akitain/enchantmentoverhaul/mixin/PlayerExhaustionMixin.java
+++ b/src/main/java/com/akitain/enchantmentoverhaul/mixin/PlayerExhaustionMixin.java
@@ -1,0 +1,37 @@
+package com.akitain.enchantmentoverhaul.mixin;
+
+import com.akitain.enchantmentoverhaul.enchant.ModEnchantments;
+import net.minecraft.component.DataComponentTypes;
+import net.minecraft.component.type.ItemEnchantmentsComponent;
+import net.minecraft.entity.EquipmentSlot;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+@Mixin(PlayerEntity.class)
+public class PlayerExhaustionMixin {
+
+    private static final EquipmentSlot[] ARMOR_SLOTS = {
+            EquipmentSlot.HEAD, EquipmentSlot.CHEST, EquipmentSlot.LEGS, EquipmentSlot.FEET
+    };
+
+    @ModifyVariable(method = "addExhaustion", at = @At("HEAD"), argsOnly = true, ordinal = 0)
+    private float applyCurseOfHunger(float exhaustion) {
+        PlayerEntity self = (PlayerEntity) (Object) this;
+        int cursedPieces = 0;
+        for (EquipmentSlot slot : ARMOR_SLOTS) {
+            ItemStack stack = self.getEquippedStack(slot);
+            ItemEnchantmentsComponent enchantments = stack.getOrDefault(DataComponentTypes.ENCHANTMENTS, ItemEnchantmentsComponent.DEFAULT);
+            for (var entry : enchantments.getEnchantmentEntries()) {
+                if (entry.getKey().matchesKey(ModEnchantments.CURSE_OF_HUNGER)) {
+                    cursedPieces++;
+                    break;
+                }
+            }
+        }
+        if (cursedPieces == 0) return exhaustion;
+        return exhaustion * (1.0f + 0.3f * cursedPieces);
+    }
+}

--- a/src/main/java/com/akitain/enchantmentoverhaul/mixin/VeilDetectionMixin.java
+++ b/src/main/java/com/akitain/enchantmentoverhaul/mixin/VeilDetectionMixin.java
@@ -1,0 +1,47 @@
+package com.akitain.enchantmentoverhaul.mixin;
+
+import com.akitain.enchantmentoverhaul.enchant.ModEnchantments;
+import net.minecraft.component.DataComponentTypes;
+import net.minecraft.component.type.ItemEnchantmentsComponent;
+import net.minecraft.entity.EquipmentSlot;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.ai.TargetPredicate;
+import net.minecraft.entity.attribute.EntityAttributes;
+import net.minecraft.item.ItemStack;
+import net.minecraft.server.world.ServerWorld;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(TargetPredicate.class)
+public class VeilDetectionMixin {
+
+    @Shadow private double baseMaxDistance;
+    @Shadow private boolean useDistanceScalingFactor;
+
+    @Inject(method = "test", at = @At("HEAD"), cancellable = true)
+    private void applyVeil(ServerWorld world, LivingEntity attacker, LivingEntity target, CallbackInfoReturnable<Boolean> cir) {
+        if (attacker == null || target == null) return;
+
+        ItemStack helmet = target.getEquippedStack(EquipmentSlot.HEAD);
+        ItemEnchantmentsComponent enchantments = helmet.getOrDefault(DataComponentTypes.ENCHANTMENTS, ItemEnchantmentsComponent.DEFAULT);
+        boolean hasVeil = false;
+        for (var entry : enchantments.getEnchantmentEntries()) {
+            if (entry.getKey().matchesKey(ModEnchantments.VEIL)) { hasVeil = true; break; }
+        }
+        if (!hasVeil) return;
+
+        double range = this.baseMaxDistance;
+        if (this.useDistanceScalingFactor) {
+            double followRange = attacker.getAttributeValue(EntityAttributes.FOLLOW_RANGE);
+            range = Math.min(range, followRange);
+        }
+
+        double reducedRange = range * 0.25;
+        if (attacker.distanceTo(target) > reducedRange) {
+            cir.setReturnValue(false);
+        }
+    }
+}

--- a/src/main/java/com/akitain/enchantmentoverhaul/mixin/client/VeilNametagMixin.java
+++ b/src/main/java/com/akitain/enchantmentoverhaul/mixin/client/VeilNametagMixin.java
@@ -1,0 +1,48 @@
+package com.akitain.enchantmentoverhaul.mixin.client;
+
+import com.akitain.enchantmentoverhaul.enchant.ModEnchantments;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.render.entity.PlayerEntityRenderer;
+import net.minecraft.component.DataComponentTypes;
+import net.minecraft.component.type.ItemEnchantmentsComponent;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EquipmentSlot;
+import net.minecraft.entity.PlayerLikeEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.hit.BlockHitResult;
+import net.minecraft.util.hit.HitResult;
+import net.minecraft.util.math.Vec3d;
+import net.minecraft.world.RaycastContext;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(PlayerEntityRenderer.class)
+public class VeilNametagMixin {
+
+    @Inject(method = "hasLabel(Lnet/minecraft/entity/PlayerLikeEntity;D)Z", at = @At("RETURN"), cancellable = true)
+    private void hideVeilNametag(PlayerLikeEntity entity, double squaredDistance, CallbackInfoReturnable<Boolean> cir) {
+        if (!cir.getReturnValue()) return;
+
+        ItemStack helmet = entity.getEquippedStack(EquipmentSlot.HEAD);
+        ItemEnchantmentsComponent enchantments = helmet.getOrDefault(DataComponentTypes.ENCHANTMENTS, ItemEnchantmentsComponent.DEFAULT);
+        boolean hasVeil = false;
+        for (var entry : enchantments.getEnchantmentEntries()) {
+            if (entry.getKey().matchesKey(ModEnchantments.VEIL)) { hasVeil = true; break; }
+        }
+        if (!hasVeil) return;
+
+        MinecraftClient client = MinecraftClient.getInstance();
+        Entity camera = client.getCameraEntity();
+        if (camera == null) return;
+
+        Vec3d start = camera.getEyePos();
+        Vec3d end = entity.getEyePos();
+        BlockHitResult hit = entity.getEntityWorld().raycast(new RaycastContext(
+                start, end, RaycastContext.ShapeType.COLLIDER, RaycastContext.FluidHandling.NONE, camera));
+        if (hit.getType() == HitResult.Type.BLOCK) {
+            cir.setReturnValue(false);
+        }
+    }
+}

--- a/src/main/resources/assets/enchantment-overhaul/lang/en_us.json
+++ b/src/main/resources/assets/enchantment-overhaul/lang/en_us.json
@@ -2,5 +2,14 @@
   "item.enchantment-overhaul.honing_template": "Honing Smithing Template",
   "item.enchantment-overhaul.warding_template": "Warding Smithing Template",
   "item.enchantment-overhaul.tempering_template": "Tempering Smithing Template",
-  "item.enchantment-overhaul.grinding_template": "Grinding Smithing Template"
+  "item.enchantment-overhaul.grinding_template": "Grinding Smithing Template",
+  "enchantment.enchantment-overhaul.step_up": "Step-Up",
+  "enchantment.enchantment-overhaul.venom": "Venom",
+  "enchantment.enchantment-overhaul.last_stand": "Last Stand",
+  "enchantment.enchantment-overhaul.curse_of_fragility": "Curse of Fragility",
+  "enchantment.enchantment-overhaul.curse_of_hunger": "Curse of Hunger",
+  "enchantment.enchantment-overhaul.veil": "Veil",
+  "enchantment.enchantment-overhaul.buoyancy": "Buoyancy",
+  "enchantment.enchantment-overhaul.magnetic": "Magnetic",
+  "enchantment.enchantment-overhaul.homing": "Homing"
 }

--- a/src/main/resources/data/enchantment-overhaul/enchantment/buoyancy.json
+++ b/src/main/resources/data/enchantment-overhaul/enchantment/buoyancy.json
@@ -1,0 +1,22 @@
+{
+    "anvil_cost": 2,
+    "description": {
+        "translate": "enchantment.enchantment-overhaul.buoyancy"
+    },
+    "effects": {},
+    "exclusive_set": "#minecraft:exclusive_set/boots",
+    "max_cost": {
+        "base": 25,
+        "per_level_above_first": 0
+    },
+    "max_level": 1,
+    "min_cost": {
+        "base": 10,
+        "per_level_above_first": 0
+    },
+    "slots": [
+        "feet"
+    ],
+    "supported_items": "#minecraft:enchantable/foot_armor",
+    "weight": 3
+}

--- a/src/main/resources/data/enchantment-overhaul/enchantment/curse_of_fragility.json
+++ b/src/main/resources/data/enchantment-overhaul/enchantment/curse_of_fragility.json
@@ -1,0 +1,21 @@
+{
+    "anvil_cost": 8,
+    "description": {
+        "translate": "enchantment.enchantment-overhaul.curse_of_fragility"
+    },
+    "effects": {},
+    "max_cost": {
+        "base": 50,
+        "per_level_above_first": 0
+    },
+    "max_level": 1,
+    "min_cost": {
+        "base": 25,
+        "per_level_above_first": 0
+    },
+    "slots": [
+        "any"
+    ],
+    "supported_items": "#minecraft:enchantable/durability",
+    "weight": 1
+}

--- a/src/main/resources/data/enchantment-overhaul/enchantment/curse_of_hunger.json
+++ b/src/main/resources/data/enchantment-overhaul/enchantment/curse_of_hunger.json
@@ -1,0 +1,21 @@
+{
+    "anvil_cost": 8,
+    "description": {
+        "translate": "enchantment.enchantment-overhaul.curse_of_hunger"
+    },
+    "effects": {},
+    "max_cost": {
+        "base": 50,
+        "per_level_above_first": 0
+    },
+    "max_level": 1,
+    "min_cost": {
+        "base": 25,
+        "per_level_above_first": 0
+    },
+    "slots": [
+        "armor"
+    ],
+    "supported_items": "#minecraft:enchantable/armor",
+    "weight": 1
+}

--- a/src/main/resources/data/enchantment-overhaul/enchantment/homing.json
+++ b/src/main/resources/data/enchantment-overhaul/enchantment/homing.json
@@ -1,0 +1,21 @@
+{
+    "anvil_cost": 4,
+    "description": {
+        "translate": "enchantment.enchantment-overhaul.homing"
+    },
+    "effects": {},
+    "max_cost": {
+        "base": 30,
+        "per_level_above_first": 0
+    },
+    "max_level": 1,
+    "min_cost": {
+        "base": 15,
+        "per_level_above_first": 0
+    },
+    "slots": [
+        "mainhand"
+    ],
+    "supported_items": "#minecraft:enchantable/crossbow",
+    "weight": 2
+}

--- a/src/main/resources/data/enchantment-overhaul/enchantment/last_stand.json
+++ b/src/main/resources/data/enchantment-overhaul/enchantment/last_stand.json
@@ -1,0 +1,21 @@
+{
+    "anvil_cost": 4,
+    "description": {
+        "translate": "enchantment.enchantment-overhaul.last_stand"
+    },
+    "effects": {},
+    "max_cost": {
+        "base": 37,
+        "per_level_above_first": 10
+    },
+    "max_level": 3,
+    "min_cost": {
+        "base": 7,
+        "per_level_above_first": 10
+    },
+    "slots": [
+        "chest"
+    ],
+    "supported_items": "#minecraft:enchantable/chest_armor",
+    "weight": 2
+}

--- a/src/main/resources/data/enchantment-overhaul/enchantment/magnetic.json
+++ b/src/main/resources/data/enchantment-overhaul/enchantment/magnetic.json
@@ -1,0 +1,21 @@
+{
+    "anvil_cost": 4,
+    "description": {
+        "translate": "enchantment.enchantment-overhaul.magnetic"
+    },
+    "effects": {},
+    "max_cost": {
+        "base": 37,
+        "per_level_above_first": 10
+    },
+    "max_level": 3,
+    "min_cost": {
+        "base": 7,
+        "per_level_above_first": 10
+    },
+    "slots": [
+        "mainhand"
+    ],
+    "supported_items": "#minecraft:enchantable/mining",
+    "weight": 3
+}

--- a/src/main/resources/data/enchantment-overhaul/enchantment/step_up.json
+++ b/src/main/resources/data/enchantment-overhaul/enchantment/step_up.json
@@ -1,0 +1,30 @@
+{
+    "anvil_cost": 2,
+    "description": {
+        "translate": "enchantment.enchantment-overhaul.step_up"
+    },
+    "effects": {
+        "minecraft:attributes": [
+            {
+                "amount": 0.4,
+                "attribute": "minecraft:step_height",
+                "id": "enchantment-overhaul:enchantment.step_up",
+                "operation": "add_value"
+            }
+        ]
+    },
+    "max_cost": {
+        "base": 25,
+        "per_level_above_first": 0
+    },
+    "max_level": 1,
+    "min_cost": {
+        "base": 10,
+        "per_level_above_first": 0
+    },
+    "slots": [
+        "feet"
+    ],
+    "supported_items": "#minecraft:enchantable/foot_armor",
+    "weight": 5
+}

--- a/src/main/resources/data/enchantment-overhaul/enchantment/veil.json
+++ b/src/main/resources/data/enchantment-overhaul/enchantment/veil.json
@@ -1,0 +1,21 @@
+{
+    "anvil_cost": 4,
+    "description": {
+        "translate": "enchantment.enchantment-overhaul.veil"
+    },
+    "effects": {},
+    "max_cost": {
+        "base": 30,
+        "per_level_above_first": 0
+    },
+    "max_level": 1,
+    "min_cost": {
+        "base": 15,
+        "per_level_above_first": 0
+    },
+    "slots": [
+        "head"
+    ],
+    "supported_items": "#minecraft:enchantable/head_armor",
+    "weight": 2
+}

--- a/src/main/resources/data/enchantment-overhaul/enchantment/venom.json
+++ b/src/main/resources/data/enchantment-overhaul/enchantment/venom.json
@@ -1,0 +1,50 @@
+{
+    "anvil_cost": 4,
+    "description": {
+        "translate": "enchantment.enchantment-overhaul.venom"
+    },
+    "effects": {
+        "minecraft:post_attack": [
+            {
+                "affected": "victim",
+                "effect": {
+                    "type": "minecraft:apply_mob_effect",
+                    "to_apply": "minecraft:poison",
+                    "min_duration": {
+                        "type": "minecraft:linear",
+                        "base": 80.0,
+                        "per_level_above_first": 40.0
+                    },
+                    "max_duration": {
+                        "type": "minecraft:linear",
+                        "base": 80.0,
+                        "per_level_above_first": 40.0
+                    },
+                    "min_amplifier": 0.0,
+                    "max_amplifier": 0.0
+                },
+                "enchanted": "attacker",
+                "requirements": {
+                    "condition": "minecraft:damage_source_properties",
+                    "predicate": {
+                        "is_direct": true
+                    }
+                }
+            }
+        ]
+    },
+    "max_cost": {
+        "base": 37,
+        "per_level_above_first": 20
+    },
+    "max_level": 2,
+    "min_cost": {
+        "base": 7,
+        "per_level_above_first": 20
+    },
+    "slots": [
+        "mainhand"
+    ],
+    "supported_items": "#enchantment-overhaul:enchantable/venom",
+    "weight": 3
+}

--- a/src/main/resources/data/enchantment-overhaul/tags/item/enchantable/venom.json
+++ b/src/main/resources/data/enchantment-overhaul/tags/item/enchantable/venom.json
@@ -1,0 +1,6 @@
+{
+    "values": [
+        "#minecraft:swords",
+        "#minecraft:spears"
+    ]
+}

--- a/src/main/resources/data/minecraft/tags/enchantment/curse.json
+++ b/src/main/resources/data/minecraft/tags/enchantment/curse.json
@@ -1,0 +1,7 @@
+{
+    "replace": false,
+    "values": [
+        "enchantment-overhaul:curse_of_fragility",
+        "enchantment-overhaul:curse_of_hunger"
+    ]
+}

--- a/src/main/resources/data/minecraft/tags/enchantment/exclusive_set/boots.json
+++ b/src/main/resources/data/minecraft/tags/enchantment/exclusive_set/boots.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+        "enchantment-overhaul:buoyancy"
+    ]
+}

--- a/src/main/resources/data/minecraft/tags/enchantment/non_treasure.json
+++ b/src/main/resources/data/minecraft/tags/enchantment/non_treasure.json
@@ -1,0 +1,12 @@
+{
+    "replace": false,
+    "values": [
+        "enchantment-overhaul:step_up",
+        "enchantment-overhaul:venom",
+        "enchantment-overhaul:last_stand",
+        "enchantment-overhaul:veil",
+        "enchantment-overhaul:buoyancy",
+        "enchantment-overhaul:magnetic",
+        "enchantment-overhaul:homing"
+    ]
+}

--- a/src/main/resources/enchantment-overhaul.mixins.json
+++ b/src/main/resources/enchantment-overhaul.mixins.json
@@ -15,9 +15,15 @@
         "GrindstoneScreenHandlerMixin",
         "SmithingScreenHandlerMixin",
         "ItemStackDamageMixin",
-        "LivingEntityDamageMixin"
+        "LivingEntityDamageMixin",
+        "PlayerExhaustionMixin",
+        "BuoyancyMixin",
+        "VeilDetectionMixin",
+        "HomingProjectileMixin"
     ],
-    "client": [],
+    "client": [
+        "client.VeilNametagMixin"
+    ],
     "injectors": {
         "defaultRequire": 1
     }


### PR DESCRIPTION
## Summary

Adds all 9 new enchantments from the design doc (minus Reach, Molten, Soulbound which were dropped). Step-Up and Venom are fully data-driven via JSON effects. Last Stand, Curse of Fragility, Curse of Hunger, Buoyancy, Veil, Magnetic, and Homing use server/client mixins for custom behavior. Includes enchantment JSONs, registry keys, reagent costs, item/enchantment tags, exclusive sets, and lang entries.

## Test plan
- Apply each enchantment via catalogue and verify the effect works in-game
- Test Buoyancy exclusivity with Depth Strider/Frost Walker
- Test Veil mob detection range reduction and nametag hiding behind walls
- Test Magnetic item attraction at each level
- Test Homing bolt tracking on crossbow