### PR TITLE
Fix template upgrades matching vanilla enchantments (1.20.1)

### DIFF
--- a/src/main/java/com/akitain/enchantmentoverhaul/mixin/GrindingSpeedMixin.java
+++ b/src/main/java/com/akitain/enchantmentoverhaul/mixin/GrindingSpeedMixin.java
@@ -19,6 +19,10 @@ public class GrindingSpeedMixin {
         int level = ModComponents.getInt(tool, ModComponents.GRINDING_LEVEL, 0);
         if (level <= 0) return;
 
-        cir.setReturnValue(cir.getReturnValue() + level * 5.0f);
+        float baseSpeed = cir.getReturnValue();
+        if (baseSpeed <= 1.0f) return;
+
+        int cappedLevel = Math.min(level, 5);
+        cir.setReturnValue(baseSpeed + cappedLevel * cappedLevel + 1.0f);
     }
 }

--- a/src/main/java/com/akitain/enchantmentoverhaul/mixin/ItemStackDamageMixin.java
+++ b/src/main/java/com/akitain/enchantmentoverhaul/mixin/ItemStackDamageMixin.java
@@ -3,6 +3,7 @@ package com.akitain.enchantmentoverhaul.mixin;
 import com.akitain.enchantmentoverhaul.component.ModComponents;
 import com.akitain.enchantmentoverhaul.enchant.ModEnchantments;
 import net.minecraft.enchantment.EnchantmentHelper;
+import net.minecraft.item.ArmorItem;
 import net.minecraft.item.ItemStack;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.math.random.Random;
@@ -19,9 +20,10 @@ public class ItemStackDamageMixin {
 
         int temperingLevel = ModComponents.getInt(self, ModComponents.TEMPERING_LEVEL, 0);
         if (temperingLevel > 0) {
+            int unbreakingLevel = unbreakingEquivalentLevel(temperingLevel);
             int reduced = 0;
             for (int i = 0; i < amount; i++) {
-                if (random.nextInt(temperingLevel + 1) == 0) reduced++;
+                if (shouldApplyTemperedDamage(self, unbreakingLevel, random)) reduced++;
             }
             amount = reduced;
         }
@@ -31,5 +33,16 @@ public class ItemStackDamageMixin {
         }
 
         return amount;
+    }
+
+    private static int unbreakingEquivalentLevel(int temperingLevel) {
+        return Math.max(1, Math.round(Math.min(temperingLevel, 5) * 3.0f / 5.0f));
+    }
+
+    private static boolean shouldApplyTemperedDamage(ItemStack stack, int unbreakingLevel, Random random) {
+        if (stack.getItem() instanceof ArmorItem && random.nextFloat() < 0.6f) {
+            return true;
+        }
+        return random.nextInt(unbreakingLevel + 1) == 0;
     }
 }

--- a/src/main/java/com/akitain/enchantmentoverhaul/mixin/LivingEntityDamageMixin.java
+++ b/src/main/java/com/akitain/enchantmentoverhaul/mixin/LivingEntityDamageMixin.java
@@ -27,6 +27,8 @@ public class LivingEntityDamageMixin {
     private static final EquipmentSlot[] ARMOR_SLOTS = {
             EquipmentSlot.HEAD, EquipmentSlot.CHEST, EquipmentSlot.LEGS, EquipmentSlot.FEET
     };
+    private static final float PROTECTION_REDUCTION_PER_LEVEL = 0.04f;
+    private static final float WARDING_TO_PROTECTION_SCALE = 4.0f / 5.0f;
 
     private static float getWardingMultiplier(LivingEntity entity) {
         int totalEpf = 0;
@@ -35,7 +37,7 @@ public class LivingEntityDamageMixin {
         }
         if (totalEpf <= 0) return 1.0f;
         int capped = Math.min(totalEpf, 20);
-        return 1.0f - (capped * 0.032f);
+        return 1.0f - (capped * PROTECTION_REDUCTION_PER_LEVEL * WARDING_TO_PROTECTION_SCALE);
     }
 
     private static float getLastStandMultiplier(LivingEntity entity) {

--- a/src/main/java/com/akitain/enchantmentoverhaul/smithing/UpgradeType.java
+++ b/src/main/java/com/akitain/enchantmentoverhaul/smithing/UpgradeType.java
@@ -1,14 +1,17 @@
 package com.akitain.enchantmentoverhaul.smithing;
 
+import com.google.common.collect.Multimap;
 import com.akitain.enchantmentoverhaul.component.ModComponents;
 import net.minecraft.entity.EquipmentSlot;
+import net.minecraft.entity.attribute.EntityAttribute;
 import net.minecraft.entity.attribute.EntityAttributeModifier;
-import net.minecraft.entity.attribute.EntityAttributes;
 import net.minecraft.item.*;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.nbt.NbtElement;
 import net.minecraft.nbt.NbtList;
+import net.minecraft.registry.Registries;
 
+import java.util.Map;
 import java.util.UUID;
 
 public enum UpgradeType {
@@ -18,7 +21,6 @@ public enum UpgradeType {
     GRINDING(ModComponents.GRINDING_LEVEL);
 
     private static final UUID HONING_UUID = UUID.fromString("a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d");
-    private static final UUID GRINDING_UUID = UUID.fromString("b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e");
 
     private final String nbtKey;
 
@@ -46,27 +48,29 @@ public enum UpgradeType {
     }
 
     public void applyTo(ItemStack stack, int level) {
-        int oldLevel = currentLevel(stack);
         ModComponents.setInt(stack, nbtKey, level);
 
         switch (this) {
-            case HONING -> boostAttackDamage(stack, level - oldLevel);
+            case HONING -> boostAttackDamage(stack, level);
             case GRINDING -> {} // applied via mixin on getBlockBreakingSpeed
             case WARDING, TEMPERING -> {}
         }
     }
 
-    private void boostAttackDamage(ItemStack stack, double bonus) {
+    private void boostAttackDamage(ItemStack stack, int level) {
+        double bonus = sharpnessBonus(level);
         NbtCompound nbt = stack.getOrCreateNbt();
         NbtList modifiers = nbt.contains("AttributeModifiers", NbtElement.LIST_TYPE)
                 ? nbt.getList("AttributeModifiers", NbtElement.COMPOUND_TYPE)
                 : new NbtList();
 
+        ensureDefaultMainhandModifiers(stack, modifiers);
+
         boolean found = false;
         for (int i = 0; i < modifiers.size(); i++) {
             NbtCompound mod = modifiers.getCompound(i);
             if (isUuid(mod, HONING_UUID)) {
-                mod.putDouble("Amount", mod.getDouble("Amount") + bonus);
+                mod.putDouble("Amount", bonus);
                 found = true;
                 break;
             }
@@ -84,6 +88,33 @@ public enum UpgradeType {
         }
 
         nbt.put("AttributeModifiers", modifiers);
+    }
+
+    private static double sharpnessBonus(int level) {
+        int cappedLevel = Math.min(level, 5);
+        return cappedLevel <= 0 ? 0.0 : 1.0 + (cappedLevel - 1) * 0.5;
+    }
+
+    private static void ensureDefaultMainhandModifiers(ItemStack stack, NbtList modifiers) {
+        Multimap<EntityAttribute, EntityAttributeModifier> defaultModifiers =
+                stack.getItem().getAttributeModifiers(EquipmentSlot.MAINHAND);
+
+        for (Map.Entry<EntityAttribute, EntityAttributeModifier> entry : defaultModifiers.entries()) {
+            EntityAttributeModifier modifier = entry.getValue();
+            if (containsUuid(modifiers, modifier.getId())) continue;
+
+            NbtCompound mod = modifier.toNbt();
+            mod.putString("AttributeName", Registries.ATTRIBUTE.getId(entry.getKey()).toString());
+            mod.putString("Slot", "mainhand");
+            modifiers.add(mod);
+        }
+    }
+
+    private static boolean containsUuid(NbtList modifiers, UUID target) {
+        for (int i = 0; i < modifiers.size(); i++) {
+            if (isUuid(modifiers.getCompound(i), target)) return true;
+        }
+        return false;
     }
 
     private static boolean isUuid(NbtCompound mod, UUID target) {


### PR DESCRIPTION
Refs #51

Bug explanation:
- Honing on 1.20.1 wrote a custom `AttributeModifiers` NBT list without first preserving the item’s vanilla attack modifiers. On swords, that replaced the normal base attack damage/speed modifiers, so applying Honing could reduce actual damage.
- Template scaling also did not consistently match the vanilla enchantments these templates replace. This makes max-tier templates line up with their vanilla equivalents: Honing V = Sharpness V, Grinding V = Efficiency V, Warding V = Protection IV, and Tempering V = Unbreaking III.

Verification:
- `./gradlew -Dorg.gradle.java.home=/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home build`