### PR TITLE
Fix template upgrades matching vanilla enchantments (1.21.11)

### DIFF
--- a/src/main/java/com/akitain/enchantmentoverhaul/mixin/ItemStackDamageMixin.java
+++ b/src/main/java/com/akitain/enchantmentoverhaul/mixin/ItemStackDamageMixin.java
@@ -7,8 +7,10 @@ import net.minecraft.component.type.ItemEnchantmentsComponent;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.item.ItemStack;
 import net.minecraft.registry.RegistryKey;
+import net.minecraft.registry.tag.ItemTags;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.random.Random;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -24,9 +26,10 @@ public class ItemStackDamageMixin {
 
         int temperingLevel = self.getOrDefault(ModComponents.TEMPERING_LEVEL, 0);
         if (temperingLevel > 0) {
+            int unbreakingLevel = unbreakingEquivalentLevel(temperingLevel);
             int reduced = 0;
             for (int i = 0; i < result; i++) {
-                if (world.getRandom().nextInt(temperingLevel + 1) == 0) reduced++;
+                if (shouldApplyTemperedDamage(self, unbreakingLevel, world.getRandom())) reduced++;
             }
             result = reduced;
         }
@@ -36,6 +39,17 @@ public class ItemStackDamageMixin {
         }
 
         cir.setReturnValue(result);
+    }
+
+    private static int unbreakingEquivalentLevel(int temperingLevel) {
+        return Math.max(1, Math.round(Math.min(temperingLevel, 5) * 3.0f / 5.0f));
+    }
+
+    private static boolean shouldApplyTemperedDamage(ItemStack stack, int unbreakingLevel, Random random) {
+        if (stack.isIn(ItemTags.ARMOR_ENCHANTABLE) && random.nextFloat() < 0.6f) {
+            return true;
+        }
+        return random.nextInt(unbreakingLevel + 1) == 0;
     }
 
     private static boolean hasEnchantment(ItemStack stack, RegistryKey<Enchantment> key) {

--- a/src/main/java/com/akitain/enchantmentoverhaul/mixin/LivingEntityDamageMixin.java
+++ b/src/main/java/com/akitain/enchantmentoverhaul/mixin/LivingEntityDamageMixin.java
@@ -31,6 +31,8 @@ public class LivingEntityDamageMixin {
     private static final EquipmentSlot[] ARMOR_SLOTS = {
             EquipmentSlot.HEAD, EquipmentSlot.CHEST, EquipmentSlot.LEGS, EquipmentSlot.FEET
     };
+    private static final float PROTECTION_REDUCTION_PER_LEVEL = 0.04f;
+    private static final float WARDING_TO_PROTECTION_SCALE = 4.0f / 5.0f;
 
     private static float getWardingMultiplier(LivingEntity entity) {
         int totalEpf = 0;
@@ -39,7 +41,7 @@ public class LivingEntityDamageMixin {
         }
         if (totalEpf <= 0) return 1.0f;
         int capped = Math.min(totalEpf, 20);
-        return 1.0f - (capped * 0.032f);
+        return 1.0f - (capped * PROTECTION_REDUCTION_PER_LEVEL * WARDING_TO_PROTECTION_SCALE);
     }
 
     private static float getLastStandMultiplier(LivingEntity entity) {

--- a/src/main/java/com/akitain/enchantmentoverhaul/smithing/UpgradeType.java
+++ b/src/main/java/com/akitain/enchantmentoverhaul/smithing/UpgradeType.java
@@ -50,14 +50,27 @@ public enum UpgradeType {
         stack.set(component, level);
 
         switch (this) {
-            case HONING -> boostBaseModifier(stack, EntityAttributes.ATTACK_DAMAGE, Item.BASE_ATTACK_DAMAGE_MODIFIER_ID, level - oldLevel, AttributeModifierSlot.MAINHAND);
+            case HONING -> boostBaseModifier(stack, EntityAttributes.ATTACK_DAMAGE, Item.BASE_ATTACK_DAMAGE_MODIFIER_ID,
+                    sharpnessBonus(level) - sharpnessBonus(oldLevel), AttributeModifierSlot.MAINHAND);
             case WARDING -> {}
-            case GRINDING -> replaceModifier(stack, EntityAttributes.MINING_EFFICIENCY, level * 5, AttributeModifierSlot.MAINHAND, "grinding");
+            case GRINDING -> replaceModifier(stack, EntityAttributes.MINING_EFFICIENCY, efficiencyBonus(level), AttributeModifierSlot.MAINHAND, "grinding");
             case TEMPERING -> {}
         }
     }
 
+    private static double sharpnessBonus(int level) {
+        int cappedLevel = Math.min(level, 5);
+        return cappedLevel <= 0 ? 0.0 : 1.0 + (cappedLevel - 1) * 0.5;
+    }
+
+    private static double efficiencyBonus(int level) {
+        int cappedLevel = Math.min(level, 5);
+        return cappedLevel <= 0 ? 0.0 : cappedLevel * cappedLevel + 1.0;
+    }
+
     private void boostBaseModifier(ItemStack stack, RegistryEntry<EntityAttribute> attribute, Identifier baseId, double bonus, AttributeModifierSlot slot) {
+        if (bonus == 0.0) return;
+
         AttributeModifiersComponent existing = stack.getOrDefault(DataComponentTypes.ATTRIBUTE_MODIFIERS, AttributeModifiersComponent.DEFAULT);
         AttributeModifiersComponent.Builder builder = AttributeModifiersComponent.builder();
 


### PR DESCRIPTION
Refs #51

Bug explanation:
- The template levels were being applied as raw level-based bonuses, so max-tier templates did not reliably emulate the max level of the vanilla enchantments they replace.
- This scales each template to its target vanilla equivalent: Honing V = Sharpness V, Grinding V = Efficiency V, Warding V = Protection IV, and Tempering V = Unbreaking III. Tempering also now uses the vanilla armor durability exception.

Verification:
- `./gradlew -Dorg.gradle.java.home=/Library/Java/JavaVirtualMachines/temurin-21.jdk/Contents/Home build`