### PR TITLE
Fix template upgrades matching vanilla enchantments (latest)

### DIFF
--- a/src/main/java/com/akitain/enchantmentoverhaul/mixin/ItemStackDamageMixin.java
+++ b/src/main/java/com/akitain/enchantmentoverhaul/mixin/ItemStackDamageMixin.java
@@ -6,6 +6,8 @@ import net.minecraft.core.component.DataComponents;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.tags.ItemTags;
+import net.minecraft.util.RandomSource;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.enchantment.Enchantment;
 import net.minecraft.world.item.enchantment.ItemEnchantments;
@@ -24,9 +26,10 @@ public class ItemStackDamageMixin {
 
         int temperingLevel = self.getOrDefault(ModComponents.TEMPERING_LEVEL, 0);
         if (temperingLevel > 0) {
+            int unbreakingLevel = unbreakingEquivalentLevel(temperingLevel);
             int reduced = 0;
             for (int i = 0; i < result; i++) {
-                if (world.getRandom().nextInt(temperingLevel + 1) == 0) reduced++;
+                if (shouldApplyTemperedDamage(self, unbreakingLevel, world.getRandom())) reduced++;
             }
             result = reduced;
         }
@@ -36,6 +39,17 @@ public class ItemStackDamageMixin {
         }
 
         cir.setReturnValue(result);
+    }
+
+    private static int unbreakingEquivalentLevel(int temperingLevel) {
+        return Math.max(1, Math.round(Math.min(temperingLevel, 5) * 3.0f / 5.0f));
+    }
+
+    private static boolean shouldApplyTemperedDamage(ItemStack stack, int unbreakingLevel, RandomSource random) {
+        if (stack.is(ItemTags.ARMOR_ENCHANTABLE) && random.nextFloat() < 0.6f) {
+            return true;
+        }
+        return random.nextInt(unbreakingLevel + 1) == 0;
     }
 
     private static boolean hasEnchantment(ItemStack stack, ResourceKey<Enchantment> key) {

--- a/src/main/java/com/akitain/enchantmentoverhaul/mixin/LivingEntityDamageMixin.java
+++ b/src/main/java/com/akitain/enchantmentoverhaul/mixin/LivingEntityDamageMixin.java
@@ -30,6 +30,8 @@ public class LivingEntityDamageMixin {
     private static final EquipmentSlot[] ARMOR_SLOTS = {
             EquipmentSlot.HEAD, EquipmentSlot.CHEST, EquipmentSlot.LEGS, EquipmentSlot.FEET
     };
+    private static final float PROTECTION_REDUCTION_PER_LEVEL = 0.04f;
+    private static final float WARDING_TO_PROTECTION_SCALE = 4.0f / 5.0f;
 
     private static float getWardingMultiplier(LivingEntity entity) {
         int totalEpf = 0;
@@ -38,7 +40,7 @@ public class LivingEntityDamageMixin {
         }
         if (totalEpf <= 0) return 1.0f;
         int capped = Math.min(totalEpf, 20);
-        return 1.0f - (capped * 0.032f);
+        return 1.0f - (capped * PROTECTION_REDUCTION_PER_LEVEL * WARDING_TO_PROTECTION_SCALE);
     }
 
     private static float getLastStandMultiplier(LivingEntity entity) {

--- a/src/main/java/com/akitain/enchantmentoverhaul/smithing/UpgradeType.java
+++ b/src/main/java/com/akitain/enchantmentoverhaul/smithing/UpgradeType.java
@@ -50,14 +50,27 @@ public enum UpgradeType {
         stack.set(component, level);
 
         switch (this) {
-            case HONING -> boostBaseModifier(stack, Attributes.ATTACK_DAMAGE, Item.BASE_ATTACK_DAMAGE_ID, level - oldLevel, EquipmentSlotGroup.MAINHAND);
+            case HONING -> boostBaseModifier(stack, Attributes.ATTACK_DAMAGE, Item.BASE_ATTACK_DAMAGE_ID,
+                    sharpnessBonus(level) - sharpnessBonus(oldLevel), EquipmentSlotGroup.MAINHAND);
             case WARDING -> {}
-            case GRINDING -> replaceModifier(stack, Attributes.MINING_EFFICIENCY, level * 5, EquipmentSlotGroup.MAINHAND, "grinding");
+            case GRINDING -> replaceModifier(stack, Attributes.MINING_EFFICIENCY, efficiencyBonus(level), EquipmentSlotGroup.MAINHAND, "grinding");
             case TEMPERING -> {}
         }
     }
 
+    private static double sharpnessBonus(int level) {
+        int cappedLevel = Math.min(level, 5);
+        return cappedLevel <= 0 ? 0.0 : 1.0 + (cappedLevel - 1) * 0.5;
+    }
+
+    private static double efficiencyBonus(int level) {
+        int cappedLevel = Math.min(level, 5);
+        return cappedLevel <= 0 ? 0.0 : cappedLevel * cappedLevel + 1.0;
+    }
+
     private void boostBaseModifier(ItemStack stack, Holder<Attribute> attribute, Identifier baseId, double bonus, EquipmentSlotGroup slot) {
+        if (bonus == 0.0) return;
+
         ItemAttributeModifiers existing = stack.getOrDefault(DataComponents.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.EMPTY);
         ItemAttributeModifiers.Builder builder = ItemAttributeModifiers.builder();
 


### PR DESCRIPTION
Refs #51

Bug explanation:
- The template levels were being applied as raw level-based bonuses, so max-tier templates did not reliably emulate the max level of the vanilla enchantments they replace.
- This scales each template to its target vanilla equivalent: Honing V = Sharpness V, Grinding V = Efficiency V, Warding V = Protection IV, and Tempering V = Unbreaking III. Tempering also now uses the vanilla armor durability exception.

Verification:
- `./gradlew -Dorg.gradle.java.home=/Library/Java/JavaVirtualMachines/temurin-25.jdk/Contents/Home build`