### PR TITLE
Add upgrade command for smithing templates (1.20.1)

### DIFF
--- a/src/main/java/com/akitain/enchantmentoverhaul/EnchantmentOverhaul.java
+++ b/src/main/java/com/akitain/enchantmentoverhaul/EnchantmentOverhaul.java
@@ -1,6 +1,7 @@
 package com.akitain.enchantmentoverhaul;
 
 import com.akitain.enchantmentoverhaul.component.ModComponents;
+import com.akitain.enchantmentoverhaul.command.UpgradeCommand;
 import com.akitain.enchantmentoverhaul.enchant.ModEnchantments;
 import com.akitain.enchantmentoverhaul.enchant.VillagerTrades;
 import com.akitain.enchantmentoverhaul.enchant.ModScreenHandlers;
@@ -28,6 +29,7 @@ public class EnchantmentOverhaul implements ModInitializer {
         ModScreenHandlers.register();
         SmithingTemplates.register();
         ModGameRules.register();
+        UpgradeCommand.register();
 
         ItemGroupEvents.modifyEntriesEvent(ItemGroups.INGREDIENTS).register(entries -> {
             entries.addBefore(Items.NETHERITE_UPGRADE_SMITHING_TEMPLATE,

--- a/src/main/java/com/akitain/enchantmentoverhaul/command/UpgradeCommand.java
+++ b/src/main/java/com/akitain/enchantmentoverhaul/command/UpgradeCommand.java
@@ -1,0 +1,74 @@
+package com.akitain.enchantmentoverhaul.command;
+
+import com.akitain.enchantmentoverhaul.smithing.UpgradeType;
+import com.mojang.brigadier.arguments.IntegerArgumentType;
+import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
+import net.minecraft.item.ItemStack;
+import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.text.Text;
+
+import java.util.Locale;
+
+import static net.minecraft.server.command.CommandManager.argument;
+import static net.minecraft.server.command.CommandManager.literal;
+
+public class UpgradeCommand {
+
+    private static final int MAX_LEVEL = 5;
+
+    public static void register() {
+        CommandRegistrationCallback.EVENT.register((dispatcher, registryAccess, environment) ->
+                dispatcher.register(literal("upgrade")
+                        .requires(source -> source.hasPermissionLevel(2))
+                        .then(literal("honing").executes(context -> apply(context.getSource(), UpgradeType.HONING, MAX_LEVEL))
+                                .then(argument("level", IntegerArgumentType.integer(1, MAX_LEVEL))
+                                        .executes(context -> apply(context.getSource(), UpgradeType.HONING, IntegerArgumentType.getInteger(context, "level")))))
+                        .then(literal("warding").executes(context -> apply(context.getSource(), UpgradeType.WARDING, MAX_LEVEL))
+                                .then(argument("level", IntegerArgumentType.integer(1, MAX_LEVEL))
+                                        .executes(context -> apply(context.getSource(), UpgradeType.WARDING, IntegerArgumentType.getInteger(context, "level")))))
+                        .then(literal("tempering").executes(context -> apply(context.getSource(), UpgradeType.TEMPERING, MAX_LEVEL))
+                                .then(argument("level", IntegerArgumentType.integer(1, MAX_LEVEL))
+                                        .executes(context -> apply(context.getSource(), UpgradeType.TEMPERING, IntegerArgumentType.getInteger(context, "level")))))
+                        .then(literal("grinding").executes(context -> apply(context.getSource(), UpgradeType.GRINDING, MAX_LEVEL))
+                                .then(argument("level", IntegerArgumentType.integer(1, MAX_LEVEL))
+                                        .executes(context -> apply(context.getSource(), UpgradeType.GRINDING, IntegerArgumentType.getInteger(context, "level")))))));
+    }
+
+    private static int apply(ServerCommandSource source, UpgradeType type, int level) {
+        if (source.getPlayer() == null) {
+            source.sendError(Text.literal("This command can only be used by a player."));
+            return 0;
+        }
+
+        ItemStack stack = source.getPlayer().getMainHandStack();
+        if (stack.isEmpty()) {
+            source.sendError(Text.literal("Hold an item before using /upgrade."));
+            return 0;
+        }
+
+        if (!type.appliesTo(stack)) {
+            source.sendError(Text.literal(typeName(type) + " cannot be applied to this item."));
+            return 0;
+        }
+
+        type.applyTo(stack, level);
+        source.sendFeedback(() -> Text.literal("Applied " + typeName(type) + " " + roman(level) + " to held item."), true);
+        return 1;
+    }
+
+    private static String typeName(UpgradeType type) {
+        String lower = type.name().toLowerCase(Locale.ROOT);
+        return Character.toUpperCase(lower.charAt(0)) + lower.substring(1);
+    }
+
+    private static String roman(int level) {
+        return switch (level) {
+            case 1 -> "I";
+            case 2 -> "II";
+            case 3 -> "III";
+            case 4 -> "IV";
+            case 5 -> "V";
+            default -> String.valueOf(level);
+        };
+    }
+}


### PR DESCRIPTION
Refs #47

Adds an operator/debug command for applying smithing template upgrades directly to the currently held item:

- `/upgrade honing [level]`
- `/upgrade warding [level]`
- `/upgrade tempering [level]`
- `/upgrade grinding [level]`

The command requires permission level 2, defaults to level V when no level is provided, validates that the selected upgrade applies to the held item, and then reuses the existing `UpgradeType.applyTo` behavior.

Verification:
- `./gradlew -Dorg.gradle.java.home=/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home build`