### PR TITLE
fix: anvil repair consumes only the materials needed (1.20.1)

### DIFF
--- a/src/main/java/com/akitain/enchantmentoverhaul/mixin/AnvilScreenHandlerMixin.java
+++ b/src/main/java/com/akitain/enchantmentoverhaul/mixin/AnvilScreenHandlerMixin.java
@@ -26,6 +26,7 @@ public abstract class AnvilScreenHandlerMixin extends ForgingScreenHandler {
 
     @Shadow @Nullable private String newItemName;
     @Shadow @Final private Property levelCost;
+    @Shadow private int repairItemUsage;
 
     private AnvilScreenHandlerMixin(@Nullable ScreenHandlerType<?> type, int syncId, PlayerInventory playerInventory, ScreenHandlerContext context) {
         super(type, syncId, playerInventory, context);
@@ -43,17 +44,16 @@ public abstract class AnvilScreenHandlerMixin extends ForgingScreenHandler {
 
         ItemStack result = first.copy();
         int restoreCost = tryRestoreSlot(first, second, result);
-        boolean changed = (restoreCost > 0) | tryRepair(first, second, result) | tryRename(first, result);
-
-        if (!second.isEmpty() && !changed) {
-            clearOutput(ci);
-            return;
-        }
+        int repairUnits = tryRepair(first, second, result);
+        boolean renamed = tryRename(first, result);
+        boolean changed = restoreCost > 0 || repairUnits > 0 || renamed;
 
         if (!changed) {
             clearOutput(ci);
             return;
         }
+
+        this.repairItemUsage = repairUnits > 0 ? repairUnits : (restoreCost > 0 ? 1 : 0);
 
         if (result.hasNbt()) result.getNbt().remove("RepairCost");
         this.levelCost.set(Math.max(1, restoreCost));
@@ -95,20 +95,21 @@ public abstract class AnvilScreenHandlerMixin extends ForgingScreenHandler {
         return 2;
     }
 
-    private boolean tryRepair(ItemStack first, ItemStack second, ItemStack result) {
-        if (second.isEmpty() || !first.isDamageable() || !first.getItem().canRepair(first, second)) return false;
+    private int tryRepair(ItemStack first, ItemStack second, ItemStack result) {
+        if (second.isEmpty() || !first.isDamageable() || !first.getItem().canRepair(first, second)) return 0;
 
-        int damage = first.getDamage();
         int repairPerUnit = first.getMaxDamage() / 4;
+        int damage = first.getDamage();
+        if (repairPerUnit <= 0 || damage <= 0) return 0;
 
-        for (int i = 0; i < second.getCount() && damage > 0; i++) {
+        int units = 0;
+        while (units < second.getCount() && damage > 0) {
             damage = Math.max(0, damage - repairPerUnit);
+            units++;
         }
 
-        if (damage >= first.getDamage()) return false;
-
         result.setDamage(damage);
-        return true;
+        return units;
     }
 
     private boolean tryRename(ItemStack first, ItemStack result) {
@@ -124,6 +125,7 @@ public abstract class AnvilScreenHandlerMixin extends ForgingScreenHandler {
     }
 
     private void clearOutput(CallbackInfo ci) {
+        this.repairItemUsage = 0;
         this.output.setStack(0, ItemStack.EMPTY);
         this.levelCost.set(0);
         ci.cancel();


### PR DESCRIPTION
Backport of the anvil fix to the 1.20.1 line. tryRepair returns the number of material units used and the mixin writes it to repairItemUsage, so the anvil consumes only what the repair needed instead of the whole stack. This version has no keepSecondSlot field, so only repairItemUsage is set. Resolves #62 on 1.20.1.