### PR TITLE
feat: Easy Anvils anvil compatibility (1.21.11)

### DIFF
--- a/src/main/java/com/akitain/enchantmentoverhaul/mixin/AnvilScreenHandlerMixin.java
+++ b/src/main/java/com/akitain/enchantmentoverhaul/mixin/AnvilScreenHandlerMixin.java
@@ -2,6 +2,7 @@ package com.akitain.enchantmentoverhaul.mixin;
 
 import com.akitain.enchantmentoverhaul.component.ModComponents;
 import com.akitain.enchantmentoverhaul.enchant.SlotSystem;
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.component.DataComponentTypes;
 import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.item.Item;
@@ -19,6 +20,7 @@ import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -31,6 +33,9 @@ public abstract class AnvilScreenHandlerMixin extends ForgingScreenHandler {
     @Shadow private int repairItemUsage;
     @Shadow private boolean keepSecondSlot;
 
+    @Unique
+    private static final boolean EASY_ANVILS = FabricLoader.getInstance().isModLoaded("easyanvils");
+
     private AnvilScreenHandlerMixin(@Nullable ScreenHandlerType<?> type, int syncId, PlayerInventory playerInventory, ScreenHandlerContext context, ForgingSlotsManager forgingSlotsManager) {
         super(type, syncId, playerInventory, context, forgingSlotsManager);
     }
@@ -42,6 +47,10 @@ public abstract class AnvilScreenHandlerMixin extends ForgingScreenHandler {
 
         if (first.isEmpty()) {
             clearOutput(ci);
+            return;
+        }
+
+        if (EASY_ANVILS && shouldDeferToEasyAnvils(first, second)) {
             return;
         }
 
@@ -64,6 +73,15 @@ public abstract class AnvilScreenHandlerMixin extends ForgingScreenHandler {
         this.levelCost.set(Math.max(1, restoreCost));
         this.output.setStack(0, result);
         ci.cancel();
+    }
+
+    @Unique
+    private boolean shouldDeferToEasyAnvils(ItemStack first, ItemStack second) {
+        if (second.isEmpty()) return true;
+        if (first.canRepairWith(second)) return false;
+        if (SlotSystem.getGrindstonePenalty(first) > 0 && second.isOf(getRepairIngot(first))) return false;
+        if (second.contains(DataComponentTypes.STORED_ENCHANTMENTS)) return false;
+        return true;
     }
 
     private int tryRestoreSlot(ItemStack first, ItemStack second, ItemStack result) {


### PR DESCRIPTION
When Easy Anvils is installed, Enchantment Overhaul now cedes the operations it does not own. For a plain rename or for combining two damaged tools, EO skips its createResult takeover so Easy Anvils' own deferral applies its features (free renames, formatted and colored names, tool combining). EO keeps owning material repair, grindstone-penalty restore, and blocking anvil book enchanting, which is its spirit. Without Easy Anvils nothing changes, since the path is guarded by a mod-loaded check. The only coupling is FabricLoader.isModLoaded, with no calls into Easy Anvils internals. Resolves #58. Backport to the 1.21.11 line.