### PR TITLE
fix: make Venom mutually exclusive with Fire Aspect (#67)

### DIFF
--- a/src/main/resources/data/enchantment-overhaul/enchantment/venom.json
+++ b/src/main/resources/data/enchantment-overhaul/enchantment/venom.json
@@ -33,6 +33,9 @@
             }
         ]
     },
+    "exclusive_set": [
+        "minecraft:fire_aspect"
+    ],
     "max_cost": {
         "base": 37,
         "per_level_above_first": 20


### PR DESCRIPTION
Venom and Fire Aspect could both sit on the same weapon. This adds an exclusive_set on the Venom enchantment so the two are mutually exclusive in both the anvil and the enchanting table, relying on vanilla's symmetric compatibility check so only Venom's definition needs to change. Resolves #67.