### PR TITLE
fix: make Venom mutually exclusive with Fire Aspect (#67)

### DIFF
--- a/src/main/resources/data/enchantment-overhaul/enchantment/venom.json
+++ b/src/main/resources/data/enchantment-overhaul/enchantment/venom.json
@@ -33,6 +33,9 @@
             }
         ]
     },
+    "exclusive_set": [
+        "minecraft:fire_aspect"
+    ],
     "max_cost": {
         "base": 37,
         "per_level_above_first": 20


### PR DESCRIPTION
Backports the Venom and Fire Aspect mutual-exclusivity fix to the 1.21.11 release line so it reaches current players. Same one-line exclusive_set change as the dev PR for #67.