### PR TITLE
fix: make Venom mutually exclusive with Fire Aspect (#67)

### DIFF
--- a/src/main/java/com/akitain/enchantmentoverhaul/enchant/enchantments/VenomEnchantment.java
+++ b/src/main/java/com/akitain/enchantmentoverhaul/enchant/enchantments/VenomEnchantment.java
@@ -2,6 +2,7 @@ package com.akitain.enchantmentoverhaul.enchant.enchantments;
 
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.enchantment.EnchantmentTarget;
+import net.minecraft.enchantment.Enchantments;
 import net.minecraft.entity.EquipmentSlot;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.SwordItem;
@@ -21,6 +22,11 @@ public class VenomEnchantment extends Enchantment {
 
     @Override
     public int getMaxLevel() { return 2; }
+
+    @Override
+    public boolean canAccept(Enchantment other) {
+        return other != Enchantments.FIRE_ASPECT && super.canAccept(other);
+    }
 
     @Override
     public boolean isAcceptableItem(ItemStack stack) {


### PR DESCRIPTION
Backports the Venom and Fire Aspect mutual-exclusivity fix to the 1.20.1 release line. 1.20.1 predates data-driven enchantments, so instead of an exclusive_set this overrides canAccept on VenomEnchantment to reject Fire Aspect, relying on the engine's symmetric canCombine check. Same intent as #67.