### PR TITLE
feat: legendary unrepairable state for Venom + Fire Aspect items

### DIFF
--- a/src/main/java/com/akitain/enchantmentoverhaul/enchant/CatalogueScreenHandler.java
+++ b/src/main/java/com/akitain/enchantmentoverhaul/enchant/CatalogueScreenHandler.java
@@ -101,7 +101,7 @@ public class CatalogueScreenHandler extends ScreenHandler {
 
     public void rebuildEntries() {
         ItemStack item = this.inputInventory.getStack(0);
-        if (item.isEmpty()) {
+        if (item.isEmpty() || LegendaryItems.isLegendary(item)) {
             this.entries = List.of();
             return;
         }
@@ -145,7 +145,7 @@ public class CatalogueScreenHandler extends ScreenHandler {
         }
 
         ItemStack item = inputInventory.getStack(0);
-        if (item.isEmpty()) {
+        if (item.isEmpty() || LegendaryItems.isLegendary(item)) {
             outputInventory.setStack(0, ItemStack.EMPTY);
             return;
         }

--- a/src/main/java/com/akitain/enchantmentoverhaul/enchant/LegendaryItems.java
+++ b/src/main/java/com/akitain/enchantmentoverhaul/enchant/LegendaryItems.java
@@ -1,0 +1,25 @@
+package com.akitain.enchantmentoverhaul.enchant;
+
+import net.minecraft.enchantment.EnchantmentHelper;
+import net.minecraft.enchantment.Enchantments;
+import net.minecraft.item.ItemStack;
+import net.minecraft.text.Style;
+import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
+
+public final class LegendaryItems {
+
+    public static final Formatting COLOR = Formatting.GOLD;
+
+    private LegendaryItems() {}
+
+    public static boolean isLegendary(ItemStack stack) {
+        return EnchantmentHelper.getLevel(ModEnchantments.VENOM, stack) > 0
+                && EnchantmentHelper.getLevel(Enchantments.FIRE_ASPECT, stack) > 0;
+    }
+
+    public static Text tooltip() {
+        return Text.translatable("item.enchantment-overhaul.legendary.tooltip")
+                .setStyle(Style.EMPTY.withColor(COLOR));
+    }
+}

--- a/src/main/java/com/akitain/enchantmentoverhaul/mixin/AnvilScreenHandlerMixin.java
+++ b/src/main/java/com/akitain/enchantmentoverhaul/mixin/AnvilScreenHandlerMixin.java
@@ -1,6 +1,7 @@
 package com.akitain.enchantmentoverhaul.mixin;
 
 import com.akitain.enchantmentoverhaul.component.ModComponents;
+import com.akitain.enchantmentoverhaul.enchant.LegendaryItems;
 import com.akitain.enchantmentoverhaul.enchant.SlotSystem;
 import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.item.Item;
@@ -38,6 +39,11 @@ public abstract class AnvilScreenHandlerMixin extends ForgingScreenHandler {
         ItemStack second = this.input.getStack(1);
 
         if (first.isEmpty()) {
+            clearOutput(ci);
+            return;
+        }
+
+        if (LegendaryItems.isLegendary(first)) {
             clearOutput(ci);
             return;
         }

--- a/src/main/java/com/akitain/enchantmentoverhaul/mixin/LegendaryMendingMixin.java
+++ b/src/main/java/com/akitain/enchantmentoverhaul/mixin/LegendaryMendingMixin.java
@@ -1,0 +1,24 @@
+package com.akitain.enchantmentoverhaul.mixin;
+
+import com.akitain.enchantmentoverhaul.enchant.LegendaryItems;
+import java.util.Map;
+import java.util.function.Predicate;
+import net.minecraft.enchantment.Enchantment;
+import net.minecraft.enchantment.EnchantmentHelper;
+import net.minecraft.entity.EquipmentSlot;
+import net.minecraft.entity.ExperienceOrbEntity;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.item.ItemStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(ExperienceOrbEntity.class)
+public class LegendaryMendingMixin {
+
+    @Redirect(method = "repairPlayerGears", at = @At(value = "INVOKE",
+            target = "Lnet/minecraft/enchantment/EnchantmentHelper;chooseEquipmentWith(Lnet/minecraft/enchantment/Enchantment;Lnet/minecraft/entity/LivingEntity;Ljava/util/function/Predicate;)Ljava/util/Map$Entry;"))
+    private Map.Entry<EquipmentSlot, ItemStack> excludeLegendaryFromMending(Enchantment enchantment, LivingEntity entity, Predicate<ItemStack> predicate) {
+        return EnchantmentHelper.chooseEquipmentWith(enchantment, entity, stack -> predicate.test(stack) && !LegendaryItems.isLegendary(stack));
+    }
+}

--- a/src/main/java/com/akitain/enchantmentoverhaul/mixin/LegendaryNameMixin.java
+++ b/src/main/java/com/akitain/enchantmentoverhaul/mixin/LegendaryNameMixin.java
@@ -1,0 +1,21 @@
+package com.akitain.enchantmentoverhaul.mixin;
+
+import com.akitain.enchantmentoverhaul.enchant.LegendaryItems;
+import net.minecraft.item.ItemStack;
+import net.minecraft.text.Style;
+import net.minecraft.text.Text;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import net.minecraft.item.Item;
+
+@Mixin(Item.class)
+public class LegendaryNameMixin {
+
+    @Inject(method = "getName(Lnet/minecraft/item/ItemStack;)Lnet/minecraft/text/Text;", at = @At("RETURN"), cancellable = true)
+    private void colorLegendaryName(ItemStack stack, CallbackInfoReturnable<Text> cir) {
+        if (!LegendaryItems.isLegendary(stack)) return;
+        cir.setReturnValue(cir.getReturnValue().copy().setStyle(Style.EMPTY.withColor(LegendaryItems.COLOR)));
+    }
+}

--- a/src/main/java/com/akitain/enchantmentoverhaul/mixin/client/LegendaryTooltipMixin.java
+++ b/src/main/java/com/akitain/enchantmentoverhaul/mixin/client/LegendaryTooltipMixin.java
@@ -1,0 +1,23 @@
+package com.akitain.enchantmentoverhaul.mixin.client;
+
+import com.akitain.enchantmentoverhaul.enchant.LegendaryItems;
+import java.util.List;
+import net.minecraft.client.item.TooltipContext;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.text.Text;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(Item.class)
+public class LegendaryTooltipMixin {
+
+    @Inject(method = "appendTooltip", at = @At("TAIL"))
+    private void appendLegendaryTooltip(ItemStack stack, World world, List<Text> tooltip, TooltipContext context, CallbackInfo ci) {
+        if (!LegendaryItems.isLegendary(stack)) return;
+        tooltip.add(LegendaryItems.tooltip());
+    }
+}

--- a/src/main/resources/assets/enchantment-overhaul/lang/en_us.json
+++ b/src/main/resources/assets/enchantment-overhaul/lang/en_us.json
@@ -23,6 +23,7 @@
   "enchantment.enchantment-overhaul.step_up.desc": "Walk up full-block obstacles without jumping. Disabled while sneaking.",
   "enchantment.enchantment-overhaul.venom": "Venom",
   "enchantment.enchantment-overhaul.venom.desc": "Applies Poison to the target on hit.",
+  "item.enchantment-overhaul.legendary.tooltip": "Legendary — too unstable to repair or re-enchant",
   "enchantment.enchantment-overhaul.last_stand": "Last Stand",
   "enchantment.enchantment-overhaul.last_stand.desc": "Below 20% health, take 10% less damage per level.",
   "enchantment.enchantment-overhaul.curse_of_fragility": "Curse of Fragility",

--- a/src/main/resources/assets/enchantment-overhaul/lang/fr_fr.json
+++ b/src/main/resources/assets/enchantment-overhaul/lang/fr_fr.json
@@ -23,6 +23,7 @@
   "enchantment.enchantment-overhaul.step_up.desc": "Grimpe sur les blocs sans avoir à sauter. Désactivé en s'accroupissant.",
   "enchantment.enchantment-overhaul.venom": "Venin",
   "enchantment.enchantment-overhaul.venom.desc": "Empoisonne la cible au contact.",
+  "item.enchantment-overhaul.legendary.tooltip": "Légendaire — trop instable pour être réparé ou ré-enchanté",
   "enchantment.enchantment-overhaul.last_stand": "Baroud d'Honneur",
   "enchantment.enchantment-overhaul.last_stand.desc": "Sous 20 % de vie, subit 10 % de dégâts en moins par niveau.",
   "enchantment.enchantment-overhaul.curse_of_fragility": "Malédiction de Fragilité",

--- a/src/main/resources/enchantment-overhaul.mixins.json
+++ b/src/main/resources/enchantment-overhaul.mixins.json
@@ -11,6 +11,8 @@
         "EnchantBookFactoryMixin",
         "EnchantmentNameMixin",
         "EnchantedBookNameMixin",
+        "LegendaryNameMixin",
+        "LegendaryMendingMixin",
         "ItemGroupsMixin",
         "EnchantingTableBlockMixin",
         "GrindstoneScreenHandlerMixin",
@@ -35,6 +37,7 @@
         "accessor.EntityAccessor"
     ],
     "client": [
+        "client.LegendaryTooltipMixin",
         "client.VeilNametagMixin",
         "client.EnchantingTableParticleMixin",
         "client.UpgradeOverlayMixin",


### PR DESCRIPTION
Items that already carry both Venom and Fire Aspect become a legendary state derived purely from their current enchantments: a gold name with an explainer tooltip, no repair by any means (mending, anvil, anvil combine), and no enchantments added or levels changed. Removing either enchantment via the grindstone reverts the item to normal. Follows up #67 for the grandfathered case. Targets the 1.20.1 line.