### PR TITLE
fix: custom repairs coexist with vanilla/mods + material repair for combine-only items (#62)

### DIFF
--- a/src/main/java/com/akitain/enchantmentoverhaul/mixin/AnvilScreenHandlerMixin.java
+++ b/src/main/java/com/akitain/enchantmentoverhaul/mixin/AnvilScreenHandlerMixin.java
@@ -41,12 +41,15 @@ public abstract class AnvilScreenHandlerMixin extends ItemCombinerMenu {
         ItemStack first = this.inputSlots.getItem(0);
         ItemStack second = this.inputSlots.getItem(1);
 
-        if (first.isEmpty()) {
+        if (first.isEmpty()) return;
+
+        if (LegendaryItems.isLegendary(first)) {
             clearOutput(ci);
             return;
         }
 
-        if (LegendaryItems.isLegendary(first)) {
+        // Enchanting stays exclusive to the Catalogue: never merge enchanted books on the anvil.
+        if (second.is(Items.ENCHANTED_BOOK)) {
             clearOutput(ci);
             return;
         }
@@ -54,17 +57,15 @@ public abstract class AnvilScreenHandlerMixin extends ItemCombinerMenu {
         ItemStack result = first.copy();
         int restoreCost = tryRestoreSlot(first, second, result);
         int repairUnits = tryRepair(first, second, result);
-        boolean renamed = tryRename(first, result);
-        boolean changed = restoreCost > 0 || repairUnits > 0 || renamed;
 
-        if (!changed) {
-            clearOutput(ci);
-            return;
-        }
+        // Not a mod-handled operation: let vanilla and other mods run (combine two items, modded/datapack repairs, rename).
+        if (restoreCost <= 0 && repairUnits <= 0) return;
 
-        int unitsConsumed = repairUnits > 0 ? repairUnits : (restoreCost > 0 ? 1 : 0);
+        tryRename(first, result);
+
+        int unitsConsumed = repairUnits > 0 ? repairUnits : 1;
         this.repairItemCountCost = unitsConsumed;
-        this.onlyRenaming = unitsConsumed == 0;
+        this.onlyRenaming = false;
 
         result.remove(DataComponents.REPAIR_COST);
         this.cost.set(Math.max(1, restoreCost));

--- a/src/main/java/com/akitain/enchantmentoverhaul/mixin/AnvilScreenHandlerMixin.java
+++ b/src/main/java/com/akitain/enchantmentoverhaul/mixin/AnvilScreenHandlerMixin.java
@@ -108,7 +108,8 @@ public abstract class AnvilScreenHandlerMixin extends ItemCombinerMenu {
     }
 
     private int tryRepair(ItemStack first, ItemStack second, ItemStack result) {
-        if (second.isEmpty() || !first.isDamageableItem() || !first.isValidRepairItem(second)) return 0;
+        if (second.isEmpty() || !first.isDamageableItem()) return 0;
+        if (!first.isValidRepairItem(second) && !isCombineOnlyRepairItem(first, second)) return 0;
 
         int repairPerUnit = first.getMaxDamage() / 4;
         int damage = first.getDamageValue();
@@ -122,6 +123,25 @@ public abstract class AnvilScreenHandlerMixin extends ItemCombinerMenu {
 
         result.setDamageValue(damage);
         return units;
+    }
+
+    // Items vanilla can only repair by combining two of them (no repair ingredient): give them a material repair
+    // so players don't have to sacrifice a second copy. Mending and vanilla combine still work too.
+    private static boolean isCombineOnlyRepairItem(ItemStack stack, ItemStack material) {
+        Item repairMaterial = combineOnlyRepairMaterial(stack.getItem());
+        return repairMaterial != null && material.is(repairMaterial);
+    }
+
+    private static Item combineOnlyRepairMaterial(Item item) {
+        if (item == Items.BOW
+                || item == Items.CROSSBOW
+                || item == Items.FISHING_ROD
+                || item == Items.CARROT_ON_A_STICK
+                || item == Items.WARPED_FUNGUS_ON_A_STICK) return Items.STRING;
+        if (item == Items.SHEARS || item == Items.FLINT_AND_STEEL) return Items.IRON_INGOT;
+        if (item == Items.BRUSH) return Items.COPPER_INGOT;
+        if (item == Items.TRIDENT) return Items.PRISMARINE_SHARD;
+        return null;
     }
 
     private boolean tryRename(ItemStack first, ItemStack result) {


### PR DESCRIPTION
The mod's anvil fully replaced vanilla and disabled grid repair, so other mods' and datapacks' custom repairs were ignored. The anvil now only takes over the cases it owns (legendary block, grindstone-penalty restore, and its consume-only-needed material repair) and lets vanilla and other mods handle everything else: combine-two-items, modded and datapack repairs, and renaming. Enchanting stays exclusive to the Catalogue (enchanted books are still rejected) and the 2x2 grid repair stays off by design. Additionally, items vanilla can only repair by combining two of them (bow, crossbow, fishing rod, carrot and warped fungus on a stick, shears, flint and steel, brush, trident) can now be repaired with a material instead of sacrificing a second copy.

Resolves #62.