### PR TITLE
feat: repair netherite with diamonds

### DIFF
--- a/src/main/resources/data/minecraft/tags/item/netherite_tool_materials.json
+++ b/src/main/resources/data/minecraft/tags/item/netherite_tool_materials.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "minecraft:diamond"
+  ]
+}

--- a/src/main/resources/data/minecraft/tags/item/repairs_netherite_armor.json
+++ b/src/main/resources/data/minecraft/tags/item/repairs_netherite_armor.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "minecraft:diamond"
+  ]
+}


### PR DESCRIPTION
Makes netherite tools and armor repairable with diamonds, in addition to netherite ingots. On 26.1.x and 1.21.11 this is two additive vanilla tag files (netherite_tool_materials and repairs_netherite_armor). On 1.20.1, where repair materials are hardcoded in the material enums, a small mixin adds diamond to ToolMaterials.NETHERITE and ArmorMaterials.NETHERITE. Works through the standard repair path, so it applies in the anvil, the grindstone, and Enchantment Overhaul's own anvil.