### PR TITLE
feat: repair netherite with diamonds (1.20.1)

### DIFF
--- a/src/main/java/com/akitain/enchantmentoverhaul/mixin/ArmorMaterialsMixin.java
+++ b/src/main/java/com/akitain/enchantmentoverhaul/mixin/ArmorMaterialsMixin.java
@@ -1,0 +1,20 @@
+package com.akitain.enchantmentoverhaul.mixin;
+
+import net.minecraft.item.ArmorMaterials;
+import net.minecraft.item.Items;
+import net.minecraft.recipe.Ingredient;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(ArmorMaterials.class)
+public class ArmorMaterialsMixin {
+
+    @Inject(method = "getRepairIngredient", at = @At("HEAD"), cancellable = true)
+    private void repairNetheriteWithDiamond(CallbackInfoReturnable<Ingredient> cir) {
+        if ((Object) this == ArmorMaterials.NETHERITE) {
+            cir.setReturnValue(Ingredient.ofItems(Items.NETHERITE_INGOT, Items.DIAMOND));
+        }
+    }
+}

--- a/src/main/java/com/akitain/enchantmentoverhaul/mixin/ToolMaterialsMixin.java
+++ b/src/main/java/com/akitain/enchantmentoverhaul/mixin/ToolMaterialsMixin.java
@@ -1,0 +1,20 @@
+package com.akitain.enchantmentoverhaul.mixin;
+
+import net.minecraft.item.Items;
+import net.minecraft.item.ToolMaterials;
+import net.minecraft.recipe.Ingredient;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(ToolMaterials.class)
+public class ToolMaterialsMixin {
+
+    @Inject(method = "getRepairIngredient", at = @At("HEAD"), cancellable = true)
+    private void repairNetheriteWithDiamond(CallbackInfoReturnable<Ingredient> cir) {
+        if ((Object) this == ToolMaterials.NETHERITE) {
+            cir.setReturnValue(Ingredient.ofItems(Items.NETHERITE_INGOT, Items.DIAMOND));
+        }
+    }
+}

--- a/src/main/resources/enchantment-overhaul.mixins.json
+++ b/src/main/resources/enchantment-overhaul.mixins.json
@@ -5,6 +5,8 @@
     "mixins": [
         "EnchantmentScreenHandlerMixin",
         "AnvilScreenHandlerMixin",
+        "ToolMaterialsMixin",
+        "ArmorMaterialsMixin",
         "EnchantWithLevelsLootFunctionMixin",
         "EnchantRandomlyLootFunctionMixin",
         "MobEntityMixin",


### PR DESCRIPTION
Makes netherite tools and armor repairable with diamonds, in addition to netherite ingots. On 26.1.x and 1.21.11 this is two additive vanilla tag files (netherite_tool_materials and repairs_netherite_armor). On 1.20.1, where repair materials are hardcoded in the material enums, a small mixin adds diamond to ToolMaterials.NETHERITE and ArmorMaterials.NETHERITE. Works through the standard repair path, so it applies in the anvil, the grindstone, and Enchantment Overhaul's own anvil.