### PR TITLE
feat: restore grindstone slots with any valid repair material

### DIFF
--- a/docs/Anvil-and-Grindstone.md
+++ b/docs/Anvil-and-Grindstone.md
@@ -16,7 +16,7 @@ The anvil is a maintenance station. Enchantment combining has been removed. Book
 
 ### Slot Restoration
 
-After a grindstone removes enchantments and applies a -1 slot penalty, the anvil restores the lost slot. Place the item in the left slot and the matching repair material in the right slot.
+After a grindstone removes enchantments and applies a -1 slot penalty, the anvil restores the lost slot. Place the item in the left slot and any of its repair materials in the right slot. Restoration accepts the same materials that repair the item's durability, so anything added by tags, datapacks, or other mods works too.
 
 ![Anvil restoring a grindstone penalty on a Diamond Sword](images/anvil-restore.png)
 
@@ -24,7 +24,7 @@ Repair Materials:
 
 | Item Material | Repair Material |
 |---|---|
-| Netherite | Netherite Ingot |
+| Netherite | Netherite Ingot or Diamond |
 | Diamond | Diamond |
 | Gold | Gold Ingot |
 | Iron / Chainmail | Iron Ingot |

--- a/src/main/java/com/akitain/enchantmentoverhaul/mixin/AnvilScreenHandlerMixin.java
+++ b/src/main/java/com/akitain/enchantmentoverhaul/mixin/AnvilScreenHandlerMixin.java
@@ -75,9 +75,7 @@ public abstract class AnvilScreenHandlerMixin extends ItemCombinerMenu {
     private int tryRestoreSlot(ItemStack first, ItemStack second, ItemStack result) {
         int penalty = SlotSystem.getGrindstonePenalty(first);
         if (penalty <= 0 || second.isEmpty()) return 0;
-
-        Item repairIngot = getRepairIngot(first);
-        if (repairIngot == null || !second.is(repairIngot)) return 0;
+        if (!first.isValidRepairItem(second)) return 0;
 
         result.set(ModComponents.GRINDSTONE_PENALTY, penalty - 1);
         return getRestoreCost(first);


### PR DESCRIPTION
Slot restoration now uses the item's repair materials (the repairable check, same as durability repair) instead of a single hardcoded ingot. After 0.6.1 that means a netherite slot can be restored with a diamond as well as a netherite ingot, and any repair material added by tags, datapacks, or other mods works too. The XP cost is unchanged, still based on the item's own material.