### PR TITLE
feat: restore grindstone slots with any valid repair material (1.20.1)

### DIFF
--- a/src/main/java/com/akitain/enchantmentoverhaul/mixin/AnvilScreenHandlerMixin.java
+++ b/src/main/java/com/akitain/enchantmentoverhaul/mixin/AnvilScreenHandlerMixin.java
@@ -70,9 +70,7 @@ public abstract class AnvilScreenHandlerMixin extends ForgingScreenHandler {
     private int tryRestoreSlot(ItemStack first, ItemStack second, ItemStack result) {
         int penalty = SlotSystem.getGrindstonePenalty(first);
         if (penalty <= 0 || second.isEmpty()) return 0;
-
-        Item repairIngot = getRepairIngot(first);
-        if (repairIngot == null || !second.isOf(repairIngot)) return 0;
+        if (!first.getItem().canRepair(first, second)) return 0;
 
         ModComponents.setInt(result, ModComponents.GRINDSTONE_PENALTY, penalty - 1);
         return getRestoreCost(first);


### PR DESCRIPTION
Slot restoration now uses the item's repair materials (the repairable check, same as durability repair) instead of a single hardcoded ingot. After 0.6.1 that means a netherite slot can be restored with a diamond as well as a netherite ingot, and any repair material added by tags, datapacks, or other mods works too. The XP cost is unchanged, still based on the item's own material.